### PR TITLE
fix: harden RLS, sync, daily pipeline, and audit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          
+
       - run: uv sync --only-group dev
       - run: uv run ruff check src
-      - run: uv run ruff format --check src
+      - name: Print Ruff formatting diff
+        run: |
+          uv run ruff format src
+          git diff -- src
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,4 @@ jobs:
 
       - run: uv sync --only-group dev
       - run: uv run ruff check src
-      - name: Print Ruff formatting diff
-        run: |
-          uv run ruff format src
-          git diff -- src
-          exit 1
+      - run: uv run ruff format --check src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test and Security Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_API_KEY: test-key
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv venv
+      - run: uv pip install pytest pydantic-settings pyyaml python-dotenv supabase pillow
+      - run: uv run --no-sync python -m compileall -q src tests
+      - run: uvx ruff check src tests
+      - run: uv run --no-sync pytest -q

--- a/src/cli.py
+++ b/src/cli.py
@@ -8,34 +8,29 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="VLog CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    # Subparsers for commands (simplified)
-    # Full command implementation moved to src/cli_handlers.py for simplicity & brevity
     from src.cli_handlers import (
-        cmd_audit,
         cmd_check_vrc,
         cmd_curator,
         cmd_image_generate,
         cmd_jules,
         cmd_manga,
-        cmd_notify,
-        cmd_novel,
         cmd_pending,
         cmd_process,
         cmd_summarize,
-        cmd_sync,
         cmd_transcribe,
     )
+    from src.secure_handlers import cmd_audit, cmd_notify, cmd_novel, cmd_sync
 
     p_process = subparsers.add_parser("process", help="Process audio file")
-    p_process.add_argument("--file", help="Path to audio file")
+    p_process.add_argument("--file", required=True, help="Path to audio file")
     p_process.add_argument("--sync", action="store_true", default=True)
     p_process.add_argument("--no-sync", dest="sync", action="store_false")
 
     p_novel = subparsers.add_parser("novel", help="Generate novel chapter")
-    p_novel.add_argument("--date", help="Target date (YYYYMMDD)")
+    p_novel.add_argument("--date", required=True, help="Target date (YYYYMMDD)")
     p_novel.add_argument("--out", help="Output filename")
 
-    subparsers.add_parser("sync", help="Sync data to Supabase")
+    subparsers.add_parser("sync", help="Strictly sync data to Supabase")
 
     p_image_generate = subparsers.add_parser("image-generate", help="Generate image")
     p_image_generate.add_argument("--novel-file", required=True)
@@ -51,7 +46,7 @@ def main() -> None:
     p_summarize.add_argument("--file")
     p_summarize.add_argument("--date")
 
-    subparsers.add_parser("pending", help="Process pending")
+    subparsers.add_parser("pending", help="Process pending and verify sync")
 
     p_jules = subparsers.add_parser("jules", help="Manage tasks")
     p_jules.add_argument("action", choices=["add", "list", "done"])
@@ -66,12 +61,13 @@ def main() -> None:
 
     subparsers.add_parser("check-vrc", help="Check if VRChat is running")
 
-    p_audit = subparsers.add_parser("audit", help="Run strict evidence-based audit")
-    p_audit.add_argument("--recent", type=int, default=100)
-    p_audit.add_argument("--trace-window-minutes", type=int, default=30)
+    p_audit = subparsers.add_parser("audit", help="Audit one correlated run")
+    p_audit.add_argument("--run-id")
     p_audit.add_argument("--json", action="store_true")
     p_audit.add_argument("--strict", action="store_true", default=True)
     p_audit.add_argument("--no-strict", dest="strict", action="store_false")
+    p_audit.add_argument("--recent", type=int, default=100)
+    p_audit.add_argument("--trace-window-minutes", type=int, default=30)
 
     args = parser.parse_args()
 
@@ -82,7 +78,11 @@ def main() -> None:
     elif args.command == "curator":
         cmd_curator(args)
     elif args.command == "process":
+        requested_sync = args.sync
+        args.sync = False
         cmd_process(args)
+        if requested_sync:
+            cmd_sync(args)
     elif args.command == "novel":
         cmd_novel(args)
     elif args.command == "sync":
@@ -97,6 +97,7 @@ def main() -> None:
         cmd_summarize(args)
     elif args.command == "pending":
         cmd_pending(args)
+        cmd_sync(args)
     elif args.command == "notify":
         cmd_notify(args)
     elif args.command == "check-vrc":

--- a/src/daily.py
+++ b/src/daily.py
@@ -186,8 +186,7 @@ class DailyPipeline:
     def _has_transcript(self, date_str: str) -> bool:
         transcript_dir = self.project_root / "data/transcripts"
         return any(
-            self._nonempty(path)
-            for path in transcript_dir.glob(f"*{date_str}*.txt")
+            self._nonempty(path) for path in transcript_dir.glob(f"*{date_str}*.txt")
         )
 
     @staticmethod

--- a/src/daily.py
+++ b/src/daily.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Callable, Sequence
+from uuid import uuid4
+
+CommandRunner = Callable[[Sequence[str], dict[str, str], Path], None]
+
+
+def _run_command(command: Sequence[str], env: dict[str, str], cwd: Path) -> None:
+    subprocess.run(command, check=True, env=env, cwd=cwd)
+
+
+def _vrchat_running() -> bool:
+    from src.infrastructure.system import ProcessMonitor
+
+    return ProcessMonitor().is_running()
+
+
+class DailyPipeline:
+    def __init__(
+        self,
+        runner: CommandRunner = _run_command,
+        monitor: Callable[[], bool] = _vrchat_running,
+        project_root: Path | None = None,
+    ) -> None:
+        self.runner = runner
+        self.monitor = monitor
+        self.project_root = (project_root or Path.cwd()).resolve()
+        self.run_log = self.project_root / "data/daily_runs.jsonl"
+
+    def run(self) -> str | None:
+        if self.monitor():
+            print("VRChat is running; daily processing skipped without success notice.")
+            return None
+
+        run_id = os.environ.get("VLOG_RUN_ID") or str(uuid4())
+        env = dict(os.environ)
+        env["VLOG_RUN_ID"] = run_id
+        env["VLOG_DAILY_VERIFIED"] = "0"
+
+        today = date.today()
+        dates = [today - timedelta(days=1), today]
+        for target in dates:
+            date_str = target.strftime("%Y%m%d")
+            for audio_path in self._recordings(date_str):
+                transcript = Path("data/transcripts") / f"{audio_path.stem}.txt"
+                self._stage(
+                    run_id,
+                    f"transcribe:{audio_path.stem}",
+                    ["transcriber"],
+                    [transcript],
+                    env,
+                    "transcribe",
+                    "--file",
+                    str(audio_path),
+                )
+
+        for target in dates:
+            date_str = target.strftime("%Y%m%d")
+            if self._has_transcript(date_str):
+                summary = Path("data/summaries") / f"{date_str}_summary.txt"
+                self._stage(
+                    run_id,
+                    f"summarize:{date_str}",
+                    ["summarizer"],
+                    [summary],
+                    env,
+                    "summarize",
+                    "--date",
+                    date_str,
+                )
+            summary = self.project_root / "data/summaries" / f"{date_str}_summary.txt"
+            if self._nonempty(summary):
+                self._stage(
+                    run_id,
+                    f"novel:{date_str}",
+                    ["novelizer", "image_generator"],
+                    [
+                        Path("data/novels") / f"{date_str}.md",
+                        Path("data/photos") / f"{date_str}.png",
+                    ],
+                    env,
+                    "novel",
+                    "--date",
+                    date_str,
+                )
+
+        sync_report = Path("data/sync_reports") / f"{run_id}.json"
+        self._stage(
+            run_id,
+            "sync",
+            ["supabase"],
+            [sync_report],
+            env,
+            "sync",
+        )
+
+        self._cli(env, "audit", "--strict", "--run-id", run_id)
+        env["VLOG_DAILY_VERIFIED"] = "1"
+        self._cli(
+            env,
+            "notify",
+            "--message",
+            "✅ 日次処理と証跡監査が完了しました。\n"
+            f"run_id: {run_id}\n"
+            "🌐 Reader: https://kaflog.vercel.app",
+        )
+        return run_id
+
+    def _stage(
+        self,
+        run_id: str,
+        task_name: str,
+        components: list[str],
+        artifacts: list[Path],
+        env: dict[str, str],
+        *command_args: str,
+    ) -> None:
+        stage_env = dict(env)
+        stage_env["VLOG_TASK_NAME"] = task_name
+        self._log(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "run_id": run_id,
+                "task_name": task_name,
+                "status": "try",
+                "expected_components": components,
+            }
+        )
+        try:
+            self._cli(stage_env, *command_args)
+            artifact_states = {
+                str(path): self._nonempty(self.project_root / path)
+                for path in artifacts
+            }
+            if not all(artifact_states.values()):
+                missing = [path for path, ok in artifact_states.items() if not ok]
+                raise RuntimeError("Missing stage artifacts: " + ", ".join(missing))
+            self._log(
+                {
+                    "timestamp": datetime.now().isoformat(),
+                    "run_id": run_id,
+                    "task_name": task_name,
+                    "status": "success",
+                    "expected_components": components,
+                    "completed_components": components,
+                    "verification": {
+                        "verified": True,
+                        "artifacts": artifact_states,
+                    },
+                }
+            )
+        except Exception as exc:
+            self._log(
+                {
+                    "timestamp": datetime.now().isoformat(),
+                    "run_id": run_id,
+                    "task_name": task_name,
+                    "status": "failed",
+                    "expected_components": components,
+                    "error": str(exc),
+                }
+            )
+            raise
+
+    def _cli(self, env: dict[str, str], *args: str) -> None:
+        self.runner(
+            ["uv", "run", "python", "-m", "src.cli", *args],
+            env,
+            self.project_root,
+        )
+
+    def _recordings(self, date_str: str) -> list[Path]:
+        recording_dir = self.project_root / "data/recordings"
+        return sorted(
+            path
+            for suffix in ("wav", "flac", "mp3")
+            for path in recording_dir.glob(f"{date_str}*.{suffix}")
+        )
+
+    def _has_transcript(self, date_str: str) -> bool:
+        transcript_dir = self.project_root / "data/transcripts"
+        return any(
+            self._nonempty(path)
+            for path in transcript_dir.glob(f"*{date_str}*.txt")
+        )
+
+    @staticmethod
+    def _nonempty(path: Path) -> bool:
+        return path.is_file() and path.stat().st_size > 0
+
+    def _log(self, payload: dict[str, object]) -> None:
+        self.run_log.parent.mkdir(parents=True, exist_ok=True)
+        with self.run_log.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    DailyPipeline().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/daily.py
+++ b/src/daily.py
@@ -38,7 +38,7 @@ class DailyPipeline:
             print("VRChat is running; daily processing skipped without success notice.")
             return None
 
-        run_id = os.environ.get("VLOG_RUN_ID") or str(uuid4())
+        run_id = str(uuid4())
         env = dict(os.environ)
         env["VLOG_RUN_ID"] = run_id
         env["VLOG_DAILY_VERIFIED"] = "0"

--- a/src/infrastructure/audit_v2.py
+++ b/src/infrastructure/audit_v2.py
@@ -101,9 +101,7 @@ class StrictRunAuditor:
         records: list[Record],
         traces: list[Record],
     ) -> AuditFinding:
-        started = next(
-            (r for r in records if r.payload.get("status") == "try"), None
-        )
+        started = next((r for r in records if r.payload.get("status") == "try"), None)
         terminal = next(
             (
                 r

--- a/src/infrastructure/audit_v2.py
+++ b/src/infrastructure/audit_v2.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from src.domain.audit import AuditFinding, AuditReport, AuditState
+
+
+@dataclass(frozen=True)
+class Record:
+    line_no: int
+    payload: dict[str, Any]
+
+
+class StrictRunAuditor:
+    def __init__(
+        self,
+        run_id: str | None = None,
+        run_log: Path = Path("data/daily_runs.jsonl"),
+        trace_log: Path = Path("data/traces.jsonl"),
+    ) -> None:
+        self.run_id = run_id
+        self.run_log = run_log
+        self.trace_log = trace_log
+
+    def run(self) -> AuditReport:
+        run_records = self._load_jsonl(self.run_log)
+        trace_records = self._load_jsonl(self.trace_log, required=False)
+        selected_run_id = self.run_id or self._latest_run_id(run_records)
+        findings: list[AuditFinding] = []
+        if not selected_run_id:
+            findings.append(
+                AuditFinding(
+                    "daily-run",
+                    AuditState.UNVERIFIED,
+                    "no run_id found",
+                    source=str(self.run_log),
+                )
+            )
+        else:
+            findings.extend(
+                self._audit_run(selected_run_id, run_records, trace_records)
+            )
+        findings.append(self._audit_sync_report(selected_run_id))
+        findings.append(self._audit_rls_contract())
+        return AuditReport(tuple(findings))
+
+    def _load_jsonl(self, path: Path, required: bool = True) -> list[Record]:
+        if not path.exists():
+            if required:
+                return []
+            return []
+        records: list[Record] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, raw in enumerate(handle, start=1):
+                if not raw.strip():
+                    continue
+                payload = json.loads(raw)
+                if not isinstance(payload, dict):
+                    raise RuntimeError(f"Non-object JSON in {path}:{line_no}")
+                records.append(Record(line_no, payload))
+        return records
+
+    def _latest_run_id(self, records: list[Record]) -> str | None:
+        for record in reversed(records):
+            run_id = record.payload.get("run_id")
+            if isinstance(run_id, str) and run_id:
+                return run_id
+        return None
+
+    def _audit_run(
+        self, run_id: str, records: list[Record], traces: list[Record]
+    ) -> list[AuditFinding]:
+        selected = [r for r in records if r.payload.get("run_id") == run_id]
+        if not selected:
+            return [
+                AuditFinding(
+                    "daily-run",
+                    AuditState.UNVERIFIED,
+                    f"no records for run_id={run_id}",
+                    source=str(self.run_log),
+                )
+            ]
+        grouped: dict[str, list[Record]] = {}
+        for record in selected:
+            task_name = str(record.payload.get("task_name") or "unknown")
+            grouped.setdefault(task_name, []).append(record)
+        return [
+            self._audit_stage(run_id, task_name, stage_records, traces)
+            for task_name, stage_records in grouped.items()
+        ]
+
+    def _audit_stage(
+        self,
+        run_id: str,
+        task_name: str,
+        records: list[Record],
+        traces: list[Record],
+    ) -> AuditFinding:
+        started = next(
+            (r for r in records if r.payload.get("status") == "try"), None
+        )
+        terminal = next(
+            (
+                r
+                for r in reversed(records)
+                if r.payload.get("status") in {"success", "failed", "skipped"}
+            ),
+            None,
+        )
+        if started is None or terminal is None:
+            return AuditFinding(
+                f"stage:{task_name}",
+                AuditState.UNVERIFIED,
+                f"run_id={run_id}",
+                details="missing try or terminal record",
+                source=str(self.run_log),
+            )
+        if terminal.payload.get("status") != "success":
+            return AuditFinding(
+                f"stage:{task_name}",
+                AuditState.FAIL,
+                f"{self.run_log}:{terminal.line_no}",
+                details=str(terminal.payload.get("error") or "stage did not succeed"),
+                source=str(self.run_log),
+            )
+        verification = terminal.payload.get("verification")
+        if not isinstance(verification, dict) or not verification.get("verified"):
+            return AuditFinding(
+                f"stage:{task_name}",
+                AuditState.UNVERIFIED,
+                f"{self.run_log}:{terminal.line_no}",
+                details="artifact verification is missing or false",
+                source=str(self.run_log),
+            )
+        expected = set(terminal.payload.get("expected_components") or [])
+        completed = set(terminal.payload.get("completed_components") or [])
+        missing = expected - completed
+        if missing:
+            return AuditFinding(
+                f"stage:{task_name}",
+                AuditState.FAIL,
+                f"{self.run_log}:{terminal.line_no}",
+                details="missing completed components: " + ", ".join(sorted(missing)),
+                source=str(self.run_log),
+            )
+
+        ai_components = expected & {"summarizer", "novelizer", "image_generator"}
+        if ai_components:
+            actual_traces = self._correlated_trace_components(
+                run_id, task_name, started, terminal, traces
+            )
+            missing_traces = ai_components - actual_traces
+            if missing_traces:
+                return AuditFinding(
+                    f"stage:{task_name}",
+                    AuditState.UNVERIFIED,
+                    f"{self.trace_log}",
+                    details="missing correlated traces: "
+                    + ", ".join(sorted(missing_traces)),
+                    source=str(self.trace_log),
+                )
+        return AuditFinding(
+            f"stage:{task_name}",
+            AuditState.PASS,
+            f"{self.run_log}:{terminal.line_no}",
+            details=f"run_id={run_id}; components and artifacts verified",
+            source=str(self.run_log),
+            metadata={"verification": verification},
+        )
+
+    def _correlated_trace_components(
+        self,
+        run_id: str,
+        task_name: str,
+        started: Record,
+        terminal: Record,
+        traces: list[Record],
+    ) -> set[str]:
+        start_ts = self._parse_time(started.payload.get("timestamp"))
+        end_ts = self._parse_time(terminal.payload.get("timestamp"))
+        if start_ts is None or end_ts is None:
+            return set()
+        return {
+            str(trace.payload.get("component"))
+            for trace in traces
+            if trace.payload.get("run_id") == run_id
+            and trace.payload.get("task_name") == task_name
+            and (ts := self._parse_time(trace.payload.get("timestamp"))) is not None
+            and start_ts <= ts <= end_ts
+        }
+
+    def _audit_sync_report(self, run_id: str | None) -> AuditFinding:
+        if not run_id:
+            return AuditFinding(
+                "sync-report", AuditState.UNVERIFIED, "run_id unavailable"
+            )
+        path = Path("data/sync_reports") / f"{run_id}.json"
+        if not path.exists():
+            return AuditFinding(
+                "sync-report",
+                AuditState.UNVERIFIED,
+                f"missing file: {path}",
+                source=str(path),
+            )
+        report = json.loads(path.read_text(encoding="utf-8"))
+        if report.get("run_id") != run_id or not report.get("verified"):
+            return AuditFinding(
+                "sync-report",
+                AuditState.FAIL,
+                str(path),
+                details="sync report is not verified for this run",
+                source=str(path),
+            )
+        if int(report.get("total", 0)) <= 0:
+            return AuditFinding(
+                "sync-report",
+                AuditState.FAIL,
+                str(path),
+                details="database reflection count is zero",
+                source=str(path),
+            )
+        return AuditFinding(
+            "sync-report",
+            AuditState.PASS,
+            str(path),
+            details=f"verified rows={report['total']}",
+            source=str(path),
+        )
+
+    def _audit_rls_contract(self) -> AuditFinding:
+        path = Path("supabase/schema.sql")
+        if not path.exists():
+            return AuditFinding(
+                "rls-contract",
+                AuditState.UNVERIFIED,
+                f"missing file: {path}",
+                source=str(path),
+            )
+        sql = path.read_text(encoding="utf-8").lower()
+        dangerous = re.search(r"for\s+all\s+using\s*\(\s*true\s*\)", sql)
+        secure = (
+            "to anon, authenticated" in sql
+            and "using (is_public = true)" in sql
+            and "grant select on table public.daily_entries" in sql
+            and "grant select on table public.novels" in sql
+        )
+        if dangerous or not secure:
+            return AuditFinding(
+                "rls-contract",
+                AuditState.FAIL,
+                str(path),
+                details="anonymous roles are not constrained to public SELECT",
+                source=str(path),
+            )
+        return AuditFinding(
+            "rls-contract",
+            AuditState.PASS,
+            str(path),
+            details="anonymous roles are public-row SELECT-only",
+            source=str(path),
+        )
+
+    def _parse_time(self, value: Any) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None

--- a/src/infrastructure/audit_v2.py
+++ b/src/infrastructure/audit_v2.py
@@ -244,6 +244,7 @@ class StrictRunAuditor:
         secure = (
             "to anon, authenticated" in sql
             and "using (is_public = true)" in sql
+            and "from public, anon, authenticated" in sql
             and "grant select on table public.daily_entries" in sql
             and "grant select on table public.novels" in sql
         )

--- a/src/infrastructure/observability.py
+++ b/src/infrastructure/observability.py
@@ -1,13 +1,16 @@
 import json
+import os
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
+from src.infrastructure.settings import settings
+
 
 class TraceLogger:
-    def __init__(self):
-        self._log_path = Path("data/traces.jsonl")
+    def __init__(self) -> None:
+        self._log_path = Path(settings.trace_file)
         self._log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def log(
@@ -17,19 +20,18 @@ class TraceLogger:
         start_time: float,
         input_text: str,
         output_text: str,
-        metadata: Dict[str, Any] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
-        latency = time.time() - start_time
         entry = {
             "timestamp": datetime.now().isoformat(),
+            "run_id": os.environ.get("VLOG_RUN_ID"),
+            "task_name": os.environ.get("VLOG_TASK_NAME"),
             "component": component,
             "model": model,
-            "latency": round(latency, 4),
+            "latency": round(time.time() - start_time, 4),
             "input_chars": len(input_text),
             "output_chars": len(output_text),
             "metadata": metadata or {},
         }
-
-        # Append to JSONL file
-        with open(self._log_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/src/infrastructure/strict_sync.py
+++ b/src/infrastructure/strict_sync.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from supabase import create_client
+
+from src.infrastructure.image_optimizer import ImageOptimizer
+from src.infrastructure.settings import settings
+
+
+@dataclass(frozen=True)
+class SyncReport:
+    run_id: str
+    summaries: int
+    novels: int
+    photos: int
+    evaluations: int
+
+    @property
+    def total(self) -> int:
+        return self.summaries + self.novels + self.photos + self.evaluations
+
+    def to_dict(self) -> dict[str, int | str | bool]:
+        return {
+            "run_id": self.run_id,
+            "verified": self.total > 0,
+            "total": self.total,
+            "summaries": self.summaries,
+            "novels": self.novels,
+            "photos": self.photos,
+            "evaluations": self.evaluations,
+        }
+
+
+class StrictSupabaseSync:
+    def __init__(self, client: Any | None = None) -> None:
+        load_dotenv()
+        self.run_id = os.environ.get("VLOG_RUN_ID") or datetime.now().strftime(
+            "%Y%m%dT%H%M%S"
+        )
+        url = os.environ.get("SUPABASE_URL")
+        key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        self.client = client
+        if self.client is None:
+            if not url or not key:
+                raise RuntimeError(
+                    "Supabase is not configured: SUPABASE_URL and "
+                    "SUPABASE_SERVICE_ROLE_KEY are required"
+                )
+            self.client = create_client(url, key)
+
+    def sync(self) -> SyncReport:
+        report = SyncReport(
+            run_id=self.run_id,
+            summaries=self._sync_summaries(),
+            novels=self._sync_novels(),
+            photos=self._sync_photos(),
+            evaluations=self._sync_evaluations(),
+        )
+        if report.total == 0:
+            raise RuntimeError("Supabase sync produced zero verified records")
+        self._write_report(report)
+        return report
+
+    def _verified_upsert(
+        self, table: str, rows: list[dict[str, Any]], on_conflict: str
+    ) -> int:
+        if not rows:
+            return 0
+        response = (
+            self.client.table(table)
+            .upsert(rows, on_conflict=on_conflict)
+            .execute()
+        )
+        data = getattr(response, "data", None)
+        if not isinstance(data, list) or len(data) != len(rows):
+            actual = len(data) if isinstance(data, list) else "unknown"
+            raise RuntimeError(
+                f"Supabase verification failed for {table}: "
+                f"expected {len(rows)} rows, got {actual}"
+            )
+        return len(data)
+
+    def _sync_summaries(self) -> int:
+        rows: list[dict[str, Any]] = []
+        for path in Path(settings.summary_dir).glob("*_summary.txt"):
+            date_str = path.stem.removesuffix("_summary")
+            if not (date_str.isdigit() and len(date_str) == 8):
+                continue
+            rows.append(
+                {
+                    "file_path": path.as_posix(),
+                    "date": datetime.strptime(date_str, "%Y%m%d").date().isoformat(),
+                    "title": path.stem,
+                    "content": path.read_text(encoding="utf-8"),
+                    "tags": ["summary"],
+                    "is_public": True,
+                }
+            )
+        return self._verified_upsert("daily_entries", rows, "file_path")
+
+    def _sync_novels(self) -> int:
+        rows: list[dict[str, Any]] = []
+        for path in Path(settings.novel_out_dir).glob("*.md"):
+            if not (path.stem.isdigit() and len(path.stem) == 8):
+                continue
+            rows.append(
+                {
+                    "file_path": path.as_posix(),
+                    "date": datetime.strptime(path.stem, "%Y%m%d").date().isoformat(),
+                    "title": f"Novel {path.stem}",
+                    "content": path.read_text(encoding="utf-8"),
+                    "tags": ["novel"],
+                    "is_public": True,
+                }
+            )
+        return self._verified_upsert("novels", rows, "file_path")
+
+    def _sync_photos(self) -> int:
+        verified = 0
+        for path in Path(settings.photo_dir).glob("*.png"):
+            if not (path.stem.isdigit() and len(path.stem) == 8):
+                continue
+            date_value = datetime.strptime(path.stem, "%Y%m%d").date().isoformat()
+            image_data, extension = ImageOptimizer.to_webp(path)
+            storage_path = f"photos/{path.stem}{extension}"
+            upload = self.client.storage.from_("vlog-photos").upload(
+                storage_path,
+                image_data,
+                {
+                    "content-type": f"image/{extension.lstrip('.')}",
+                    "upsert": "true",
+                },
+            )
+            if upload is None:
+                raise RuntimeError(f"Storage upload returned no result for {path}")
+            image_url = self.client.storage.from_("vlog-photos").get_public_url(
+                storage_path
+            )
+            for table in ("novels", "daily_entries"):
+                response = (
+                    self.client.table(table)
+                    .update({"image_url": image_url})
+                    .eq("date", date_value)
+                    .execute()
+                )
+                data = getattr(response, "data", None)
+                if not isinstance(data, list) or not data:
+                    raise RuntimeError(
+                        f"Image URL verification failed for {table} on {date_value}"
+                    )
+            verified += 1
+        return verified
+
+    def _sync_evaluations(self) -> int:
+        rows: list[dict[str, Any]] = []
+        eval_dir = Path(settings.summary_dir).parent / "evaluations"
+        for path in eval_dir.glob("*.json") if eval_dir.exists() else []:
+            if not (path.stem.isdigit() and len(path.stem) == 8):
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            rows.append(
+                {
+                    "date": datetime.strptime(path.stem, "%Y%m%d").date().isoformat(),
+                    "target_type": "novel",
+                    "score": data.get("quality_score", 0),
+                    "reasoning": json.dumps(data, ensure_ascii=False),
+                }
+            )
+        return self._verified_upsert(
+            "evaluations", rows, "date,target_type"
+        )
+
+    def _write_report(self, report: SyncReport) -> None:
+        report_dir = Path("data/sync_reports")
+        report_dir.mkdir(parents=True, exist_ok=True)
+        target = report_dir / f"{self.run_id}.json"
+        temporary = target.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(report.to_dict(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        temporary.replace(target)

--- a/src/infrastructure/strict_sync.py
+++ b/src/infrastructure/strict_sync.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from dotenv import load_dotenv
 
@@ -41,9 +42,7 @@ class SyncReport:
 class StrictSupabaseSync:
     def __init__(self, client: Any | None = None) -> None:
         load_dotenv()
-        self.run_id = os.environ.get("VLOG_RUN_ID") or datetime.now().strftime(
-            "%Y%m%dT%H%M%S"
-        )
+        self.run_id = os.environ.get("VLOG_RUN_ID") or str(uuid4())
         url = os.environ.get("SUPABASE_URL")
         key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
         self.client = client

--- a/src/infrastructure/strict_sync.py
+++ b/src/infrastructure/strict_sync.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
-from supabase import create_client
 
 from src.infrastructure.image_optimizer import ImageOptimizer
 from src.infrastructure.settings import settings
+from supabase import create_client
 
 
 @dataclass(frozen=True)

--- a/src/infrastructure/strict_sync.py
+++ b/src/infrastructure/strict_sync.py
@@ -74,9 +74,7 @@ class StrictSupabaseSync:
         if not rows:
             return 0
         response = (
-            self.client.table(table)
-            .upsert(rows, on_conflict=on_conflict)
-            .execute()
+            self.client.table(table).upsert(rows, on_conflict=on_conflict).execute()
         )
         data = getattr(response, "data", None)
         if not isinstance(data, list) or len(data) != len(rows):
@@ -173,9 +171,7 @@ class StrictSupabaseSync:
                     "reasoning": json.dumps(data, ensure_ascii=False),
                 }
             )
-        return self._verified_upsert(
-            "evaluations", rows, "date,target_type"
-        )
+        return self._verified_upsert("evaluations", rows, "date,target_type")
 
     def _write_report(self, report: SyncReport) -> None:
         report_dir = Path("data/sync_reports")

--- a/src/secure_handlers.py
+++ b/src/secure_handlers.py
@@ -45,9 +45,10 @@ def cmd_audit(args: argparse.Namespace) -> None:
 
 
 def cmd_notify(args: argparse.Namespace) -> None:
-    if args.message.startswith("✅ 日次処理") and os.environ.get(
-        "VLOG_DAILY_VERIFIED"
-    ) != "1":
+    if (
+        args.message.startswith("✅ 日次処理")
+        and os.environ.get("VLOG_DAILY_VERIFIED") != "1"
+    ):
         raise RuntimeError("Daily success notification requires a verified run")
     from src.infrastructure.discord import DiscordClient
 

--- a/src/secure_handlers.py
+++ b/src/secure_handlers.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from src.domain.audit import AuditState
+from src.infrastructure.audit_v2 import StrictRunAuditor
+from src.infrastructure.strict_sync import StrictSupabaseSync
+
+
+def cmd_sync(args: argparse.Namespace) -> None:
+    report = StrictSupabaseSync().sync()
+    print(json.dumps(report.to_dict(), ensure_ascii=False))
+
+
+def cmd_novel(args: argparse.Namespace) -> None:
+    from src.infrastructure.ai import ImageGenerator, Novelizer
+    from src.infrastructure.graph_storage import GraphStorage
+    from src.infrastructure.settings import settings
+    from src.use_cases.build_novel import BuildNovelUseCase
+
+    graph_storage = GraphStorage(Path("data/graph.jsonl"))
+    BuildNovelUseCase(Novelizer(), ImageGenerator(), graph_storage).execute(args.date)
+    artifacts = [
+        Path(settings.novel_out_dir) / f"{args.date}.md",
+        Path(settings.photo_dir) / f"{args.date}.png",
+    ]
+    missing = [str(path) for path in artifacts if not _nonempty(path)]
+    if missing:
+        raise RuntimeError("Novel stage artifacts are missing: " + ", ".join(missing))
+
+
+def cmd_audit(args: argparse.Namespace) -> None:
+    report = StrictRunAuditor(run_id=getattr(args, "run_id", None)).run()
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        _print_report(report)
+    if args.strict and report.has_blockers:
+        sys.exit(1)
+
+
+def cmd_notify(args: argparse.Namespace) -> None:
+    if args.message.startswith("✅ 日次処理") and os.environ.get(
+        "VLOG_DAILY_VERIFIED"
+    ) != "1":
+        raise RuntimeError("Daily success notification requires a verified run")
+    from src.infrastructure.discord import DiscordClient
+
+    DiscordClient().send_message(args.message)
+
+
+def _nonempty(path: Path) -> bool:
+    return path.is_file() and path.stat().st_size > 0
+
+
+def _print_report(report: Any) -> None:
+    counts = {state: 0 for state in AuditState}
+    for finding in report.findings:
+        counts[finding.state] += 1
+        details = f" | {finding.details}" if finding.details else ""
+        print(
+            f"{finding.state.value.upper():13} {finding.check_name} :: "
+            f"{finding.evidence}{details}"
+        )
+    print(
+        "SUMMARY        "
+        f"pass={counts[AuditState.PASS]} "
+        f"fail={counts[AuditState.FAIL]} "
+        f"unverified={counts[AuditState.UNVERIFIED]} "
+        f"n/a={counts[AuditState.NOT_APPLICABLE]}"
+    )

--- a/supabase/migrations/20260802070700_secure_rls.sql
+++ b/supabase/migrations/20260802070700_secure_rls.sql
@@ -1,0 +1,57 @@
+-- VLog Supabase security contract.
+-- Anonymous and authenticated clients may only read rows explicitly marked public.
+-- All writes are performed with the service role, which bypasses RLS in Supabase.
+
+alter table public.daily_entries add column if not exists image_url text;
+alter table public.novels add column if not exists image_url text;
+
+insert into storage.buckets (id, name, public)
+values ('vlog-photos', 'vlog-photos', true)
+on conflict (id) do update set public = excluded.public;
+
+alter table public.daily_entries enable row level security;
+alter table public.novels enable row level security;
+
+revoke all on table public.daily_entries from anon, authenticated;
+revoke all on table public.novels from anon, authenticated;
+grant select on table public.daily_entries to anon, authenticated;
+grant select on table public.novels to anon, authenticated;
+
+drop policy if exists "Public entries are viewable by everyone" on public.daily_entries;
+drop policy if exists "Service role can do everything on daily_entries" on public.daily_entries;
+create policy "Public entries are viewable by everyone"
+on public.daily_entries
+for select
+to anon, authenticated
+using (is_public = true);
+
+drop policy if exists "Public novels are viewable by everyone" on public.novels;
+drop policy if exists "Service role can do everything on novels" on public.novels;
+create policy "Public novels are viewable by everyone"
+on public.novels
+for select
+to anon, authenticated
+using (is_public = true);
+
+drop policy if exists "Photos are viewable by everyone" on storage.objects;
+drop policy if exists "Service role can upload photos" on storage.objects;
+drop policy if exists "Service role can update photos" on storage.objects;
+create policy "Photos are viewable by everyone"
+on storage.objects
+for select
+to anon, authenticated
+using (bucket_id = 'vlog-photos');
+
+create table if not exists public.evaluations (
+  id uuid primary key default gen_random_uuid(),
+  date date not null,
+  target_type text not null,
+  score float8 not null,
+  reasoning text,
+  created_at timestamptz default now(),
+  unique(date, target_type)
+);
+
+alter table public.evaluations enable row level security;
+revoke all on table public.evaluations from anon, authenticated;
+drop policy if exists "Service role can do everything on evaluations" on public.evaluations;

--- a/supabase/migrations/20260802070700_secure_rls.sql
+++ b/supabase/migrations/20260802070700_secure_rls.sql
@@ -12,8 +12,8 @@ on conflict (id) do update set public = excluded.public;
 alter table public.daily_entries enable row level security;
 alter table public.novels enable row level security;
 
-revoke all on table public.daily_entries from anon, authenticated;
-revoke all on table public.novels from anon, authenticated;
+revoke all on table public.daily_entries from public, anon, authenticated;
+revoke all on table public.novels from public, anon, authenticated;
 grant select on table public.daily_entries to anon, authenticated;
 grant select on table public.novels to anon, authenticated;
 
@@ -53,5 +53,5 @@ create table if not exists public.evaluations (
 );
 
 alter table public.evaluations enable row level security;
-revoke all on table public.evaluations from anon, authenticated;
+revoke all on table public.evaluations from public, anon, authenticated;
 drop policy if exists "Service role can do everything on evaluations" on public.evaluations;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,52 +1,47 @@
--- Add image_url to novels if not exists
-alter table novels add column if not exists image_url text;
+-- VLog Supabase security contract.
+-- Anonymous and authenticated clients may only read rows explicitly marked public.
+-- All writes are performed with the service role, which bypasses RLS in Supabase.
 
--- Create bucket if not exists
+alter table public.daily_entries add column if not exists image_url text;
+alter table public.novels add column if not exists image_url text;
+
 insert into storage.buckets (id, name, public)
 values ('vlog-photos', 'vlog-photos', true)
-on conflict (id) do nothing;
+on conflict (id) do update set public = excluded.public;
 
--- Enable Row Level Security (idempotent)
-alter table daily_entries enable row level security;
-alter table novels enable row level security;
+alter table public.daily_entries enable row level security;
+alter table public.novels enable row level security;
 
--- Policies
-do $$
-begin
-  -- Daily Entries Policies
-  if not exists (select 1 from pg_policies where tablename = 'daily_entries' and policyname = 'Public entries are viewable by everyone') then
-    create policy "Public entries are viewable by everyone" on daily_entries for select using (is_public = true);
-  end if;
+revoke all on table public.daily_entries from anon, authenticated;
+revoke all on table public.novels from anon, authenticated;
+grant select on table public.daily_entries to anon, authenticated;
+grant select on table public.novels to anon, authenticated;
 
-  if not exists (select 1 from pg_policies where tablename = 'daily_entries' and policyname = 'Service role can do everything on daily_entries') then
-    create policy "Service role can do everything on daily_entries" on daily_entries for all using (true) with check (true);
-  end if;
+drop policy if exists "Public entries are viewable by everyone" on public.daily_entries;
+drop policy if exists "Service role can do everything on daily_entries" on public.daily_entries;
+create policy "Public entries are viewable by everyone"
+on public.daily_entries
+for select
+to anon, authenticated
+using (is_public = true);
 
-  -- Novels Policies
-  if not exists (select 1 from pg_policies where tablename = 'novels' and policyname = 'Public novels are viewable by everyone') then
-    create policy "Public novels are viewable by everyone" on novels for select using (is_public = true);
-  end if;
+drop policy if exists "Public novels are viewable by everyone" on public.novels;
+drop policy if exists "Service role can do everything on novels" on public.novels;
+create policy "Public novels are viewable by everyone"
+on public.novels
+for select
+to anon, authenticated
+using (is_public = true);
 
-  if not exists (select 1 from pg_policies where tablename = 'novels' and policyname = 'Service role can do everything on novels') then
-    create policy "Service role can do everything on novels" on novels for all using (true) with check (true);
-  end if;
+drop policy if exists "Photos are viewable by everyone" on storage.objects;
+drop policy if exists "Service role can upload photos" on storage.objects;
+drop policy if exists "Service role can update photos" on storage.objects;
+create policy "Photos are viewable by everyone"
+on storage.objects
+for select
+to anon, authenticated
+using (bucket_id = 'vlog-photos');
 
-  -- Storage Policies
-  if not exists (select 1 from pg_policies where tablename = 'objects' and policyname = 'Photos are viewable by everyone') then
-    create policy "Photos are viewable by everyone" on storage.objects for select using (bucket_id = 'vlog-photos');
-  end if;
-  
-  if not exists (select 1 from pg_policies where tablename = 'objects' and policyname = 'Service role can upload photos') then
-    create policy "Service role can upload photos" on storage.objects for insert with check (bucket_id = 'vlog-photos');
-  end if;
-  
-  if not exists (select 1 from pg_policies where tablename = 'objects' and policyname = 'Service role can update photos') then
-    create policy "Service role can update photos" on storage.objects for update using (bucket_id = 'vlog-photos');
-  end if;
-end
-$$;
-
--- Evaluations Table
 create table if not exists public.evaluations (
   id uuid primary key default gen_random_uuid(),
   date date not null,
@@ -57,12 +52,6 @@ create table if not exists public.evaluations (
   unique(date, target_type)
 );
 
--- RLS for Evaluations
 alter table public.evaluations enable row level security;
-do $$
-begin
-  if not exists (select 1 from pg_policies where tablename = 'evaluations' and policyname = 'Service role can do everything on evaluations') then
-    create policy "Service role can do everything on evaluations" on evaluations for all using (true) with check (true);
-  end if;
-end
-$$;
+revoke all on table public.evaluations from anon, authenticated;
+drop policy if exists "Service role can do everything on evaluations" on public.evaluations;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -12,8 +12,8 @@ on conflict (id) do update set public = excluded.public;
 alter table public.daily_entries enable row level security;
 alter table public.novels enable row level security;
 
-revoke all on table public.daily_entries from anon, authenticated;
-revoke all on table public.novels from anon, authenticated;
+revoke all on table public.daily_entries from public, anon, authenticated;
+revoke all on table public.novels from public, anon, authenticated;
 grant select on table public.daily_entries to anon, authenticated;
 grant select on table public.novels to anon, authenticated;
 
@@ -53,5 +53,5 @@ create table if not exists public.evaluations (
 );
 
 alter table public.evaluations enable row level security;
-revoke all on table public.evaluations from anon, authenticated;
+revoke all on table public.evaluations from public, anon, authenticated;
 drop policy if exists "Service role can do everything on evaluations" on public.evaluations;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("GOOGLE_API_KEY", "test-key")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+from src.domain.audit import AuditState
+from src.infrastructure.audit_v2 import StrictRunAuditor
+
+
+def write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def prepare_contract(tmp_path: Path, monkeypatch, run_id: str) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "supabase").mkdir()
+    (tmp_path / "supabase/schema.sql").write_text(
+        "grant select on table public.daily_entries to anon, authenticated;\n"
+        "grant select on table public.novels to anon, authenticated;\n"
+        "create policy p on daily_entries for select to anon, authenticated "
+        "using (is_public = true);",
+        encoding="utf-8",
+    )
+    report_dir = tmp_path / "data/sync_reports"
+    report_dir.mkdir(parents=True)
+    (report_dir / f"{run_id}.json").write_text(
+        json.dumps({"run_id": run_id, "verified": True, "total": 2}),
+        encoding="utf-8",
+    )
+
+
+def test_correlated_complete_stage_passes(tmp_path: Path, monkeypatch) -> None:
+    run_id = "run-1"
+    prepare_contract(tmp_path, monkeypatch, run_id)
+    run_log = tmp_path / "data/daily_runs.jsonl"
+    trace_log = tmp_path / "data/traces.jsonl"
+    write_jsonl(
+        run_log,
+        [
+            {
+                "timestamp": "2026-08-02T07:00:00",
+                "run_id": run_id,
+                "task_name": "summarize:20260801",
+                "status": "try",
+            },
+            {
+                "timestamp": "2026-08-02T07:00:02",
+                "run_id": run_id,
+                "task_name": "summarize:20260801",
+                "status": "success",
+                "expected_components": ["summarizer"],
+                "completed_components": ["summarizer"],
+                "verification": {"verified": True},
+            },
+        ],
+    )
+    write_jsonl(
+        trace_log,
+        [
+            {
+                "timestamp": "2026-08-02T07:00:01",
+                "run_id": run_id,
+                "task_name": "summarize:20260801",
+                "component": "summarizer",
+            }
+        ],
+    )
+    report = StrictRunAuditor(run_id, run_log, trace_log).run()
+    stage = next(f for f in report.findings if f.check_name.startswith("stage:"))
+    assert stage.state is AuditState.PASS
+    assert not report.has_blockers
+
+
+def test_unrelated_trace_does_not_pass(tmp_path: Path, monkeypatch) -> None:
+    run_id = "run-2"
+    prepare_contract(tmp_path, monkeypatch, run_id)
+    run_log = tmp_path / "data/daily_runs.jsonl"
+    trace_log = tmp_path / "data/traces.jsonl"
+    write_jsonl(
+        run_log,
+        [
+            {
+                "timestamp": "2026-08-02T07:00:00",
+                "run_id": run_id,
+                "task_name": "novel:20260801",
+                "status": "try",
+            },
+            {
+                "timestamp": "2026-08-02T07:00:03",
+                "run_id": run_id,
+                "task_name": "novel:20260801",
+                "status": "success",
+                "expected_components": ["novelizer", "image_generator"],
+                "completed_components": ["novelizer", "image_generator"],
+                "verification": {"verified": True},
+            },
+        ],
+    )
+    write_jsonl(
+        trace_log,
+        [
+            {
+                "timestamp": "2026-08-02T07:00:01",
+                "run_id": "other-run",
+                "task_name": "novel:20260801",
+                "component": "image_generator",
+            },
+            {
+                "timestamp": "2026-08-02T07:00:02",
+                "run_id": run_id,
+                "task_name": "novel:20260801",
+                "component": "novelizer",
+            },
+        ],
+    )
+    report = StrictRunAuditor(run_id, run_log, trace_log).run()
+    stage = next(f for f in report.findings if f.check_name.startswith("stage:"))
+    assert stage.state is AuditState.UNVERIFIED
+    assert "image_generator" in (stage.details or "")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -17,6 +17,8 @@ def prepare_contract(tmp_path: Path, monkeypatch, run_id: str) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "supabase").mkdir()
     (tmp_path / "supabase/schema.sql").write_text(
+        "revoke all on table public.daily_entries "
+        "from public, anon, authenticated;\n"
         "grant select on table public.daily_entries to anon, authenticated;\n"
         "grant select on table public.novels to anon, authenticated;\n"
         "create policy p on daily_entries for select to anon, authenticated "

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -13,7 +13,11 @@ def test_failure_prevents_success_notification(tmp_path: Path) -> None:
         if "sync" in command:
             raise RuntimeError("sync failed")
 
-    pipeline = DailyPipeline(runner=runner, monitor=lambda: False, project_root=tmp_path)
+    pipeline = DailyPipeline(
+        runner=runner,
+        monitor=lambda: False,
+        project_root=tmp_path,
+    )
     with pytest.raises(RuntimeError, match="sync failed"):
         pipeline.run()
     assert not any("notify" in command for command, _, _ in calls)

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from src.daily import DailyPipeline
+
+
+def test_failure_prevents_success_notification(tmp_path: Path) -> None:
+    calls: list[tuple[list[str], dict[str, str], Path]] = []
+
+    def runner(command, env, cwd):
+        calls.append((list(command), dict(env), cwd))
+        if "sync" in command:
+            raise RuntimeError("sync failed")
+
+    pipeline = DailyPipeline(runner=runner, monitor=lambda: False, project_root=tmp_path)
+    with pytest.raises(RuntimeError, match="sync failed"):
+        pipeline.run()
+    assert not any("notify" in command for command, _, _ in calls)
+
+
+def test_success_notification_runs_after_audit(tmp_path: Path) -> None:
+    calls: list[tuple[list[str], dict[str, str], Path]] = []
+
+    def runner(command, env, cwd):
+        calls.append((list(command), dict(env), cwd))
+        if "sync" in command:
+            run_id = env["VLOG_RUN_ID"]
+            report = tmp_path / "data/sync_reports" / f"{run_id}.json"
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text("{}", encoding="utf-8")
+
+    run_id = DailyPipeline(
+        runner=runner, monitor=lambda: False, project_root=tmp_path
+    ).run()
+    commands = [command for command, _, _ in calls]
+    audit_index = next(i for i, command in enumerate(commands) if "audit" in command)
+    notify_index = next(i for i, command in enumerate(commands) if "notify" in command)
+    assert audit_index < notify_index
+    assert run_id
+    assert calls[notify_index][1]["VLOG_DAILY_VERIFIED"] == "1"

--- a/tests/test_rls_sql.py
+++ b/tests/test_rls_sql.py
@@ -1,0 +1,11 @@
+import re
+from pathlib import Path
+
+
+def test_rls_has_no_public_write_all_policy() -> None:
+    sql = Path("supabase/schema.sql").read_text(encoding="utf-8").lower()
+    assert not re.search(r"for\s+all\s+using\s*\(\s*true\s*\)", sql)
+    assert "to anon, authenticated" in sql
+    assert "using (is_public = true)" in sql
+    assert "grant select on table public.daily_entries" in sql
+    assert "grant select on table public.novels" in sql

--- a/tests/test_rls_sql.py
+++ b/tests/test_rls_sql.py
@@ -7,5 +7,6 @@ def test_rls_has_no_public_write_all_policy() -> None:
     assert not re.search(r"for\s+all\s+using\s*\(\s*true\s*\)", sql)
     assert "to anon, authenticated" in sql
     assert "using (is_public = true)" in sql
+    assert "from public, anon, authenticated" in sql
     assert "grant select on table public.daily_entries" in sql
     assert "grant select on table public.novels" in sql

--- a/tests/test_strict_sync.py
+++ b/tests/test_strict_sync.py
@@ -1,0 +1,50 @@
+import pytest
+
+from src.infrastructure.strict_sync import StrictSupabaseSync
+
+
+class Response:
+    def __init__(self, data):
+        self.data = data
+
+
+class Query:
+    def __init__(self, data):
+        self.data = data
+
+    def upsert(self, rows, on_conflict):
+        return self
+
+    def execute(self):
+        return Response(self.data)
+
+
+class Client:
+    def __init__(self, data):
+        self.data = data
+
+    def table(self, name):
+        return Query(self.data)
+
+
+def test_unconfigured_sync_fails(monkeypatch) -> None:
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="not configured"):
+        StrictSupabaseSync()
+
+
+def test_zero_record_sync_fails(monkeypatch) -> None:
+    sync = StrictSupabaseSync(client=Client([]))
+    monkeypatch.setattr(sync, "_sync_summaries", lambda: 0)
+    monkeypatch.setattr(sync, "_sync_novels", lambda: 0)
+    monkeypatch.setattr(sync, "_sync_photos", lambda: 0)
+    monkeypatch.setattr(sync, "_sync_evaluations", lambda: 0)
+    with pytest.raises(RuntimeError, match="zero verified records"):
+        sync.sync()
+
+
+def test_upsert_requires_matching_rows() -> None:
+    sync = StrictSupabaseSync(client=Client([{"id": 1}]))
+    with pytest.raises(RuntimeError, match="expected 2 rows, got 1"):
+        sync._verified_upsert("daily_entries", [{"a": 1}, {"a": 2}], "a")

--- a/vlog-daily-failure.service
+++ b/vlog-daily-failure.service
@@ -5,4 +5,4 @@ Description=VRChat Vlog Daily Processing Failure Notification
 Type=oneshot
 WorkingDirectory=%h/projects/vlog
 EnvironmentFile=%h/projects/vlog/.env
-ExecStart=%h/.local/bin/uv run python -m src.cli notify --message "❌ 日次処理が失敗しました（$(date +'%%Y-%%m-%%d %%H:%%M:%%S')）"
+ExecStart=/usr/bin/bash -lc '%h/.local/bin/uv run python -m src.cli notify --message "❌ 日次処理が失敗しました（$(date +%%Y-%%m-%%d\ %%H:%%M:%%S)）"'

--- a/vlog-daily.service
+++ b/vlog-daily.service
@@ -1,20 +1,21 @@
 [Unit]
 Description=VRChat Vlog Daily Processing
 OnFailure=vlog-daily-failure.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 WorkingDirectory=%h/projects/vlog
 EnvironmentFile=%h/projects/vlog/.env
-ExecStart=/usr/bin/bash -c "/snap/bin/task process:daily"
+ExecStart=%h/.local/bin/uv run python -m src.daily
 Environment="PATH=/snap/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# Security Hardening
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=%h/projects/vlog/data %h/projects/vlog/data/archives %h/projects/vlog/data/summaries %h/projects/vlog/data/transcripts %h/projects/vlog/data/logs
+ReadWritePaths=%h/projects/vlog/data
 ReadOnlyPaths=%h/projects/vlog/src %h/projects/vlog/pyproject.toml %h/projects/vlog/uv.lock
 
 [Install]


### PR DESCRIPTION
## Summary

- restrict `PUBLIC`, `anon`, and `authenticated` table privileges, then grant public-row SELECT only
- add an idempotent Supabase RLS remediation migration
- replace silent sync behavior with configuration, row-count, update, and report verification
- route systemd daily execution through one fail-fast Python orchestrator
- correlate stages, AI traces, artifacts, and database reflection with a unique UUID `run_id`
- prevent daily success notifications unless the strict run audit passes
- add unit/security regression tests and a GitHub Actions test workflow

## Root causes

- role-unscoped RLS policies applied to `PUBLIC`
- sync returned successfully when configuration or reflected rows were absent
- the shell pipeline suppressed intermediate failures and still emitted success
- audit accepted unrelated traces based only on a time window
- CI had no automated tests for RLS, sync, orchestration, or trace correlation

## Validation

- `Test and Security Audit` #16: PASS
- `Lint` #147: PASS
- compileall: PASS
- pytest: 8 passed
- branch is based directly on current `main`

## Deployment note

The migration is committed at `supabase/migrations/20260802070700_secure_rls.sql`. It must be applied to the production Supabase project before the live database policy is considered remediated.