### PR TITLE
feat: establish Human Memory v2 Phase 0 and repository boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
           sounddevice
           soundfile
           google-generativeai
-      - run: uv run --no-sync python -m compileall -q src tests
-      - run: uvx ruff check src tests
-      - run: uv run --no-sync pytest -q
+      - name: Compile Python sources
+        run: uv run --no-sync python -m compileall -q src packages scripts tests
+      - name: Lint Python sources
+        run: uvx ruff check src packages scripts tests
+      - name: Enforce public/private repository boundaries
+        run: uv run --no-sync python scripts/check_repository_boundaries.py
+      - name: Run tests
+        run: uv run --no-sync pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,63 @@
 # AGENTS.md
 
-## Antigravity Audit Rule
+Public OSS engine for capturing evidence, deriving reviewable human-memory claims, generating narrative artifacts, and publishing only explicitly approved projections.
 
-Before searching for `.agy`, always verify whether Antigravity CLI (`agy`) is installed.
+## Mandatory audit rule
 
-Mandatory checks:
+Before searching for `.agy`, verify whether the Antigravity CLI is installed and integrated:
 
 1. `which agy`
 2. `agy --version`
 3. `agy --help`
 4. `agy /usage`
-5. Search Taskfile, systemd services, tmux launchers, shell scripts, and cron jobs for `agy`
+5. search Taskfile, systemd units, tmux launchers, shell scripts, and cron jobs for `agy`
 
-Never infer that Antigravity is absent merely because `.agy` does not exist.
+The canonical runtime identifier is `agy`, not `.agy`. Absence of `.agy` does not prove that Antigravity is absent.
 
-The canonical runtime identifier is `agy`, not `.agy`.
+## Repository boundaries
 
-If `.agy` is not found but `agy` exists, continue investigation using the installed CLI and its integrations.
+- `apps/`: deployable capture, reader, API, and MCP entry points.
+- `packages/`: storage-agnostic domain, ingestion, narrative, privacy, and observability logic.
+- `adapters/`: PostgreSQL, Supabase Storage, Graphiti, Cognee, and Qdrant implementations.
+- `infra/`: Supabase migrations, systemd units, and Windows automation.
+- `schemas/`: versioned interchange contracts.
+- `docs/`: architecture, ADRs, and operating procedures.
 
-Failure to check `agy` before concluding Antigravity is absent is considered an audit failure.
+The current `src/` and `frontend/reader/` paths are legacy runtime locations during migration. New Human Memory v2 capabilities belong in the target boundaries. Do not create new personal diary or memory content in this public repository.
 
-VRChat Auto-Diary (vlog) 開発用エントリーポインタ。
+## Canonical pointers
 
-## 🎯 プロジェクト概要
+- [Human Memory v2 architecture](docs/architecture/human-memory-v2.md)
+- [Phase 0 inventory runbook](docs/operations/phase0-inventory.md)
+- [Current architecture](docs/architecture.md)
+- [Daily pipeline contract](docs/daily_pipeline_contract.md)
+- [Architecture decisions](docs/adr/)
+- [Python coding rules](.claude/rules/python_coding.md)
+- [General rules](.claude/rules/general.md)
+- [Commands](.claude/rules/commands.md)
+- [Model protection](.claude/rules/model_protection.md)
+- [Task runner](Taskfile.yaml)
 
-VRChatの活動を自動監視・録音し、Geminiで要約・小説化して記録するライフログシステム。
+All repository pointers must be relative Markdown links. Do not add user-specific `file://` or absolute home-directory paths.
 
-## 📍 主要ポインタ
+## Data and privacy rules
 
-詳細なルールとワークフローは以下を参照：
+- Raw audio, photo, video, full transcript, and personal conversation evidence are private-object-storage data, not Git content.
+- Private journals, people, relationships, preferences, corrections, and feedback belong in the private `kafka-memory` repository.
+- AI output starts as a candidate. It is not an accepted memory or publication decision.
+- Accepted memory claims must retain provenance to an episode/source and, where available, an utterance or time span.
+- Graphiti, Cognee, pgvector, and Qdrant are rebuildable projections, never the sole source of truth.
+- Structural migrations must not delete or move raw evidence until Phase 0 inventory and remote exports are complete.
 
-- **コーディング規約**: [.claude/rules/python_coding.md](file:///home/kafka/projects/vlog/.claude/rules/python_coding.md) / [.claude/rules/general.md](file:///home/kafka/projects/vlog/.claude/rules/general.md)
-- **コマンド・手順**: [.claude/rules/commands.md](file:///home/kafka/projects/vlog/.claude/rules/commands.md) / [Taskfile.yaml](file:///home/kafka/projects/vlog/Taskfile.yaml)
-- **アーキテクチャ定義**: [docs/architecture.md](file:///home/kafka/projects/vlog/docs/architecture.md)
-- **パイプライン契約**: [docs/daily_pipeline_contract.md](file:///home/kafka/projects/vlog/docs/daily_pipeline_contract.md)
-- **意思決定履歴**: [docs/adr/](file:///home/kafka/projects/vlog/docs/adr/)
-- **モデル名保護**: [.claude/rules/model_protection.md](file:///home/kafka/projects/vlog/.claude/rules/model_protection.md)
+## Verification
 
-## 🚀 クイックコマンド
-
-エージェントは常に以下のツールを使用して作業を検証すること：
+Run the relevant checks before completing work:
 
 ```bash
-task lint    # 保存後に自動実行される（PostToolUse）
-task status  # システム全体の稼働状況確認
-task dev     # ローカル実行テスト
+task lint
+task test
+uv run --no-sync python scripts/check_repository_boundaries.py
+uv run --no-sync python scripts/phase0_inventory.py
 ```
 
-## 🔗 外部連携
-
-- **Prompt Vault**: プロンプトのソースオブトゥルース。Kafkaのアイデンティティ設定などはここから同期する。
-  - 同期コマンド: `task vault:sync`
-  - ソース: [/home/kafka/projects/prompt-vault/](file:///home/kafka/projects/prompt-vault/)
-
-## 💡 ガイドラインと設計思想
-
-- **設定ファイルの保護について**: `.claude/settings.json` や `pyproject.toml` 等は、システムの安定性を担保するハーネスとして意図的に保護されています。これらの変更が必要な場合は、影響範囲を考慮して慎重に評価してください。
-- **ドキュメントの分散によるコンテキスト維持**: `AGENTS.md` が巨大化すると、LLMのコンテキスト領域を圧迫し要点が伝わりにくくなります。新しいルールが必要な場合は `.claude/rules/` に追加し、このファイルは軽量なポインタのリストとして機能させてください。
+Do not report runtime, Supabase, Windows, or systemd validation as complete unless it was executed in the corresponding operating environment.

--- a/README.md
+++ b/README.md
@@ -1,166 +1,111 @@
-<div align="center">
+# VLog Human Memory Engine
 
-# 🎮 VRChat Auto-Diary
+Public OSS engine for capturing VRChat evidence, deriving reviewable human-memory claims, generating narrative artifacts, and publishing only explicitly approved projections.
 
-**Transform your VRChat experiences into beautifully crafted diaries, novels, and artwork — all automatically.**
+> Migration status: Human Memory Repository v2 Phase 0/1. The current runtime remains operational in legacy `src/` and `frontend/reader/` locations while canonical boundaries, inventory, and schemas are introduced. See [Issue #14](https://github.com/KAFKA2306/vlog/issues/14).
 
-[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white)](https://python.org)
-[![Next.js](https://img.shields.io/badge/Next.js-16-black?style=flat-square&logo=next.js)](https://nextjs.org)
-[![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3ecf8e?style=flat-square&logo=supabase)](https://supabase.com)
-[![License](https://img.shields.io/badge/License-Private-gray?style=flat-square)]()
+## Architecture
 
-[Live Demo](https://kaflog.vercel.app) · [Documentation](docs/overview.md) · [Development Guide](AGENTS.md)
+```text
+Evidence
+raw audio, photos, conversations, full transcripts
+        ↓
+Human Memory
+episodes, moments, entities, claims, revisions
+        ↓
+Narrative Artifacts
+diaries, novels, illustrations, monthly reviews
+        ↓
+Public Projection
+explicitly approved artifacts only
+```
 
-</div>
+Diaries and novels are generated views, not canonical memory. AI-extracted claims begin as `candidate`; accepted claims require provenance to source evidence.
 
----
+## Repository boundaries
 
-## ✨ Features
+```text
+vlog/
+├── apps/                  deployable capture, reader, API, and MCP entry points
+├── packages/              domain, ingestion, narrative, privacy, observability
+├── adapters/              PostgreSQL, Storage, Graphiti, Cognee, Qdrant
+├── infra/                 Supabase migrations, systemd, Windows automation
+├── schemas/               versioned evidence and memory contracts
+├── docs/                  architecture, ADRs, and operations
+├── src/                   legacy runtime during migration
+└── frontend/reader/       legacy Next.js reader during migration
+```
 
-| Feature | Description |
-|---------|-------------|
-| 🎤 **Auto Recording** | Detects VRChat launch/exit and records audio automatically |
-| 📝 **AI Transcription** | Faster Whisper (large-v3-turbo) for high-accuracy speech-to-text |
-| 📖 **Smart Summaries** | Gemini 2.5 Flash transforms conversations into diary entries |
-| 📚 **Novel Generation** | Long-form narrative chapters from your daily experiences |
-| 🎨 **AI Artwork** | Auto-generated illustrations matching your story's mood |
-| ☁️ **Cloud Sync** | Seamless sync to Supabase with public/private control |
-| 🌐 **Web Reader** | Modern Next.js frontend to browse your memories |
+Private personal data is deliberately outside this public repository:
 
----
+```text
+KAFKA2306/vlog             public OSS engine
+KAFKA2306/kafka-memory     private journal and reviewed memory views
+private object storage     raw audio, photo, video, and full evidence
+public site                explicitly approved projections only
+```
 
-## 🚀 Quick Start
+## Current capabilities
 
-### Prerequisites
+- VRChat process monitoring and automatic audio capture
+- Faster Whisper transcription
+- Gemini-based diary and narrative generation
+- illustration generation
+- Supabase synchronization and Next.js reader
+- systemd and Windows supervision
+- structured operational audit and recovery tooling
 
-- Python 3.11+
-- [uv](https://github.com/astral-sh/uv) package manager
-- [Task](https://taskfile.dev) runner
+## Setup
 
-### Installation
+Requirements: Python 3.11+, [uv](https://github.com/astral-sh/uv), and [Task](https://taskfile.dev).
 
 ```bash
-# Clone and setup
-git clone https://github.com/yourusername/vlog.git
+git clone https://github.com/KAFKA2306/vlog.git
 cd vlog
 uv sync
-
-# Configure environment
 cp .env.example .env
-# Edit .env with your API keys
 ```
 
-### Run
+Common commands:
 
 ```bash
-# Linux/WSL - Start as service
+task dev
+task test
+task lint
 task up
-
-# Windows - Double-click or run
-windows\run.bat
+task status
+task sync
+task web:dev
 ```
 
----
+## Phase 0 inventory
 
-## 📁 Project Structure
+Before relocating or deleting any legacy evidence, create a read-only SHA-256 inventory:
 
-```
-vlog/
-├── src/                    # Python backend
-│   ├── infrastructure/     # AI, audio, repositories
-│   │   ├── system.py       # Recording, transcription, monitoring
-│   │   ├── ai.py           # Summarizer, Novelizer, ImageGenerator
-│   │   └── repositories.py # File, Task, Supabase repos
-│   ├── use_cases/          # Business logic
-│   └── domain/             # Entities & interfaces
-├── frontend/reader/        # Next.js web app
-├── data/                   # Local storage
-│   ├── recordings/         # Audio files (FLAC)
-│   ├── summaries/          # AI-generated diaries
-│   ├── novels/             # Long-form chapters
-│   └── photos/             # Generated artwork
-└── docs/                   # Documentation
+```bash
+uv run --no-sync python scripts/phase0_inventory.py
+uv run --no-sync python scripts/check_repository_boundaries.py
 ```
 
----
+The inventory records file counts, bytes, hashes, Git tracking state, duplicate content, and the current commit. It does not delete, move, upload, or rewrite evidence.
 
-## 🔧 Commands
+## Canonical rules
 
-| Command | Description |
-|---------|-------------|
-| `task up` | Start systemd service |
-| `task down` | Stop service |
-| `task status` | Check system status |
-| `task logs` | Real-time log streaming |
-| `task process FILE=...` | Process single audio file |
-| `task sync` | Sync to Supabase |
-| `task web:dev` | Start frontend dev server |
-| `task web:deploy` | Deploy to Vercel |
+- PostgreSQL/Supabase, private object storage, and the private memory repository are canonical stores.
+- Graphiti, Cognee, pgvector, and Qdrant are rebuildable projections.
+- raw evidence is private by default;
+- publication is a separate explicit decision;
+- ingestion idempotency uses `source_hash + pipeline_version`;
+- corrections append revisions rather than destroying prior values;
+- directory scans and file existence are legacy processing mechanisms, not the v2 state model.
 
----
+## Documentation
 
-## 🛠️ Tech Stack
+- [Human Memory v2 architecture](docs/architecture/human-memory-v2.md)
+- [Phase 0 inventory runbook](docs/operations/phase0-inventory.md)
+- [Current architecture](docs/architecture.md)
+- [Daily pipeline contract](docs/daily_pipeline_contract.md)
+- [Operations](docs/OPERATIONS.md)
+- [Agent router](AGENTS.md)
 
-<table>
-<tr>
-<td align="center" width="96">
-<b>Backend</b>
-</td>
-<td align="center" width="96">
-<b>AI/ML</b>
-</td>
-<td align="center" width="96">
-<b>Frontend</b>
-</td>
-<td align="center" width="96">
-<b>Infra</b>
-</td>
-</tr>
-<tr>
-<td align="center">
-Python 3.11<br/>
-sounddevice<br/>
-Pydantic
-</td>
-<td align="center">
-Faster Whisper<br/>
-Gemini 2.5<br/>
-Diffusers
-</td>
-<td align="center">
-Next.js 16<br/>
-React 19<br/>
-TypeScript
-</td>
-<td align="center">
-Supabase<br/>
-Vercel<br/>
-systemd
-</td>
-</tr>
-</table>
-
----
-
-## 📖 Documentation
-
-| Document | Description |
-|----------|-------------|
-| [AGENTS.md](AGENTS.md) | Development guide & coding conventions |
-| [docs/overview.md](docs/overview.md) | Complete system documentation |
-| [docs/architecture.md](docs/architecture.md) | Visual system diagrams |
-| [docs/image.md](docs/image.md) | Image generation subsystem |
-
----
-
-## 🌐 Live
-
-**Production**: [kaflog.vercel.app](https://kaflog.vercel.app)
-
----
-
-<div align="center">
-
-Made with ❤️ for VRChat memories
-
-</div>
+Production reader: [kaflog.vercel.app](https://kaflog.vercel.app)

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,11 @@
+# Adapters
+
+Vendor- and storage-specific implementations live here.
+
+- `postgres/`: canonical metadata persistence, transactions, outbox, FTS, pgvector, and RLS.
+- `supabase-storage/`: private object storage and explicit public projection buckets.
+- `graphiti/`: rebuildable temporal relationship projection.
+- `cognee/`: optional rebuildable knowledge projection.
+- `qdrant/`: optional vector index for scale beyond the PostgreSQL operating envelope.
+
+Graphiti, Cognee, pgvector, and Qdrant are projections. None may become the sole source of truth for evidence, claims, revisions, or publication decisions.

--- a/adapters/cognee/README.md
+++ b/adapters/cognee/README.md
@@ -1,0 +1,5 @@
+# cognee
+
+Optional, rebuildable knowledge projection.
+
+Cognee is not a core runtime dependency and must not be required for capture, inventory, canonical persistence, correction, or publication. Its index can be deleted and reconstructed from canonical stores.

--- a/adapters/graphiti/README.md
+++ b/adapters/graphiti/README.md
@@ -1,0 +1,5 @@
+# graphiti
+
+Rebuildable temporal relationship projection for time-varying people, preferences, promises, and entity links.
+
+Canonical history remains in PostgreSQL and reviewed private memory files. Projection rebuilds must not overwrite or erase canonical revisions.

--- a/adapters/postgres/README.md
+++ b/adapters/postgres/README.md
@@ -1,0 +1,5 @@
+# postgres
+
+Canonical metadata persistence adapter for sources, episodes, utterances, moments, entities, claims, revisions, artifacts, ingestion runs, outbox events, and publication decisions.
+
+Migrations and RLS definitions live under `infra/supabase/migrations/`.

--- a/adapters/qdrant/README.md
+++ b/adapters/qdrant/README.md
@@ -1,0 +1,5 @@
+# qdrant
+
+Optional vector projection for a scale or latency requirement that PostgreSQL/pgvector cannot satisfy.
+
+No Qdrant deployment is required in Phase 0/1. Adoption requires measured evidence and an ADR; canonical data remains elsewhere.

--- a/adapters/supabase-storage/README.md
+++ b/adapters/supabase-storage/README.md
@@ -1,0 +1,5 @@
+# supabase-storage
+
+Private object storage adapter for evidence bytes and an explicitly separate public projection path.
+
+Object listing must paginate to completion. A fixed 1000-object response is not accepted as a complete inventory or synchronization result.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,12 @@
+# Applications
+
+Deployable and user-facing entry points live here.
+
+| Boundary | Responsibility | Migration source |
+|---|---|---|
+| `capture-vrchat/` | VRChat detection, recording, transcription orchestration | current `src/app.py`, `src/main.py`, and capture-facing CLI code |
+| `reader/` | Next.js private/public reader | current `frontend/reader/` |
+| `api/` | HTTP API over canonical memory and artifacts | new |
+| `mcp/` | read-first MCP tools (`search`, `timeline`, `get_evidence`, `list_open_loops`) | new |
+
+Applications may depend on packages and adapter interfaces. Packages must not import application code.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,5 @@
+# api
+
+HTTP application boundary for canonical memory queries, artifact generation requests, correction workflows, and publication decisions.
+
+Write operations require authenticated authorization and explicit policy checks. Search projections are read accelerators and cannot bypass canonical PostgreSQL/RLS decisions.

--- a/apps/capture-vrchat/README.md
+++ b/apps/capture-vrchat/README.md
@@ -1,0 +1,5 @@
+# capture-vrchat
+
+Target application boundary for VRChat detection, audio capture, transcription orchestration, and session lifecycle control.
+
+The current implementation remains in legacy `src/` until the behavior-preserving relocation PR. This application may call package APIs and adapter protocols; it must not own canonical memory persistence rules.

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,0 +1,5 @@
+# mcp
+
+Read-first MCP application boundary.
+
+Initial tools are limited to `search`, `timeline`, `get_evidence`, and `list_open_loops`. Correct, forget, accept, and publish operations require an approval workflow and are intentionally excluded from the first MCP surface.

--- a/apps/reader/README.md
+++ b/apps/reader/README.md
@@ -1,0 +1,5 @@
+# reader
+
+Target boundary for the Next.js reader and publication review UI.
+
+The current implementation remains in legacy `frontend/reader/` until relocation. Private evidence access and public projection access must use separate authorization paths; public rendering must consume only approved artifacts.

--- a/docs/architecture/human-memory-v2.md
+++ b/docs/architecture/human-memory-v2.md
@@ -1,0 +1,93 @@
+# Human Memory Repository v2 Architecture
+
+Status: Phase 0 and Phase 1 boundary establishment
+
+Tracking issue: #14
+
+## System direction
+
+```text
+Evidence -> Human Memory -> Narrative Artifact -> Public Projection
+```
+
+The pipeline no longer treats a diary, novel, illustration, or AI summary as canonical memory. Generated artifacts are disposable projections that retain references to canonical episodes and claims.
+
+## Canonical stores
+
+| Store | Canonical responsibility |
+|---|---|
+| Private object storage | raw audio, photo, video, full transcript, and document bytes |
+| PostgreSQL/Supabase | source metadata, episodes, utterances, moments, entities, claims, revisions, ingestion runs, outbox, and publication decisions |
+| Private `kafka-memory` repository | reviewed journal text, writing policy, long-lived preferences, corrections, and human-maintained memory views |
+
+Graphiti, Cognee, pgvector, and Qdrant are rebuildable projections. They are not authoritative stores.
+
+## Public repository boundaries
+
+- `apps/`: deployable entry points.
+- `packages/`: storage-agnostic business capabilities.
+- `adapters/`: vendor and persistence implementations.
+- `infra/`: systemd, Windows, Supabase migrations, and deployment assets.
+- `schemas/`: versioned interchange contracts.
+- `docs/`: ADRs, architecture, and operations.
+
+The current `src/` and `frontend/reader/` remain legacy runtime locations during the first migration gate. New domain code must not be added to root `src/domain` unless required to repair production. New Human Memory v2 capabilities go to the target boundary.
+
+## Dependency rule
+
+```text
+apps -> packages -> protocols <- adapters
+```
+
+Forbidden directions:
+
+- packages importing apps
+- domain entities importing Supabase, Graphiti, Cognee, Qdrant, Next.js, or model SDKs
+- publication code reading raw private evidence without an explicit authorized use case
+- search indexes becoming the only copy of a claim or revision
+
+## Executable invariants
+
+The `memory-domain` package enforces:
+
+1. accepted claims require at least one provenance reference;
+2. evidence references point to a source object and episode, with an optional utterance/time span;
+3. revisions are append-only records of status changes;
+4. timestamps are timezone-aware;
+5. generated artifacts reference canonical episode or claim IDs;
+6. publication requires a separate decision record;
+7. ingestion idempotency is keyed by `source_hash + pipeline_version`.
+
+## Migration gates
+
+### Gate 0: freeze and inventory
+
+- no raw evidence deletion or relocation;
+- generate SHA-256 inventory of legacy local data;
+- record Git tracking, byte totals, duplicate hashes, and current commit;
+- export Supabase schema, rows, buckets, and RLS separately in the operating environment.
+
+### Gate 1: establish boundaries
+
+- create target directories and versioned schemas;
+- add repository boundary checks to CI;
+- make AGENTS pointers repository-relative;
+- keep current runtime behavior unchanged.
+
+### Gate 2: relocate without behavior change
+
+- move `src` runtime modules into `apps/capture-vrchat` and packages;
+- move `frontend/reader` into `apps/reader`;
+- move systemd and Windows assets into `infra`;
+- update imports, Taskfile, unit paths, tests, and deployment configuration;
+- remove legacy locations only after all tests and operating checks pass.
+
+### Gate 3: canonical persistence
+
+- add PostgreSQL migrations for v2 entities, outbox, idempotency, RLS, and publication policy;
+- change synchronization from directory scanning to outbox consumers;
+- migrate evidence bytes to private storage and retain manifests in Git/private memory views.
+
+## Rollback
+
+Each gate is a separate PR. Git history is the rollback mechanism. Raw evidence is never modified as part of a structural code migration.

--- a/docs/operations/phase0-inventory.md
+++ b/docs/operations/phase0-inventory.md
@@ -1,0 +1,74 @@
+# Phase 0 Inventory Runbook
+
+This procedure freezes the legacy evidence layout before relocation. It does not delete, move, upload, or rewrite source files.
+
+## Local inventory
+
+```bash
+uv run --no-sync python scripts/phase0_inventory.py
+```
+
+Optional explicit roots:
+
+```bash
+uv run --no-sync python scripts/phase0_inventory.py \
+  --evidence-root data/recordings \
+  --evidence-root data/transcripts \
+  --evidence-root data/photos
+```
+
+The command writes `data/inventory/phase0-<UTC timestamp>.json`. The `data/` ignore policy prevents this machine-local inventory from being committed accidentally.
+
+Each record contains:
+
+- repository-relative path;
+- category;
+- byte size and UTC modification timestamp;
+- SHA-256 digest;
+- Git tracking state;
+- symlink state and target.
+
+The summary includes category totals, tracked evidence count, and duplicate hash groups.
+
+Use the stricter mode after legacy private files have been removed from Git:
+
+```bash
+uv run --no-sync python scripts/phase0_inventory.py --fail-on-tracked-evidence
+```
+
+## Repository boundary check
+
+```bash
+uv run --no-sync python scripts/check_repository_boundaries.py
+```
+
+This check rejects:
+
+- personal memory repository roots committed to public `vlog`;
+- tracked raw audio/video;
+- tracked files above 100 MiB;
+- escaping symlinks;
+- user-specific absolute pointers in `AGENTS.md`;
+- missing v2 top-level boundaries.
+
+## Supabase inventory
+
+The local command cannot prove remote completeness. Before Storage or schema migration, export and retain the following from the operating environment:
+
+1. database schema and migration history;
+2. row counts and primary-key ranges for every table;
+3. Storage bucket list, visibility, object count, total bytes, and paginated object manifest;
+4. RLS and Storage policies;
+5. public/private state of every generated artifact;
+6. a hash or immutable export reference for each export file.
+
+Do not use a single `list(..., limit=1000)` response as a complete inventory. Continue pagination until the provider reports no remaining page.
+
+## Exit criteria
+
+Phase 0 is complete only when:
+
+- local inventory JSON exists and is retained outside the public repository;
+- remote exports are complete and independently restorable;
+- raw evidence deletion is disabled operationally;
+- counts and byte totals are recorded in the migration PR or private operations log.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,9 @@
+# Infrastructure
+
+Deployment and operations assets live here.
+
+- `supabase/migrations/`: versioned PostgreSQL, RLS, Storage, and outbox migrations.
+- `systemd/`: Linux/WSL units and installation helpers.
+- `windows/`: Windows Task Scheduler, bootstrap, and watchdog assets.
+
+Runtime paths must be derived from the repository root or explicit environment variables. Infrastructure files must not contain user-specific `/home/...` paths as portable defaults.

--- a/infra/supabase/migrations/README.md
+++ b/infra/supabase/migrations/README.md
@@ -1,0 +1,5 @@
+# Supabase migrations
+
+Versioned PostgreSQL, RLS, Storage policy, idempotency, and outbox migrations belong here.
+
+Phase 0 exports the current remote state before any migration is applied. Public/private separation must be enforced by database and Storage policy, not only by application branches.

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,5 @@
+# systemd
+
+Target location for `vlog.service`, daily services/timers, failure units, and installation helpers.
+
+Root-level units remain active during the behavior-preserving migration gate. They move here only with updated install scripts, Taskfile commands, path sandboxing, and `systemd-analyze verify` evidence.

--- a/infra/windows/README.md
+++ b/infra/windows/README.md
@@ -1,0 +1,5 @@
+# windows
+
+Target location for bootstrap scripts, scheduled-task definitions, runtime fallbacks, and external watchdogs.
+
+Migration must preserve current Windows/WSL behavior and replace user-specific paths with explicit parameters or repository-root discovery.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,11 @@
+# Packages
+
+Reusable business capabilities live here and remain independent from deployment frameworks.
+
+- `memory-domain/`: canonical entities and invariants.
+- `ingestion/`: hashing, inventory, idempotency, provenance, and outbox contracts.
+- `narrative/`: diary, novel, illustration, and review generation.
+- `privacy/`: redaction, pseudonymization, retention, and publication gates.
+- `observability/`: operational events, traces, health, and audit reporting.
+
+Dependency direction is `apps -> packages -> adapter protocols`. Search indexes and vendor SDKs are not canonical domain dependencies.

--- a/packages/ingestion/README.md
+++ b/packages/ingestion/README.md
@@ -1,0 +1,5 @@
+# ingestion
+
+Owns source hashing, read-only inventory, idempotency, provenance capture, ingestion run state, and outbox contracts.
+
+It does not generate narratives, decide publication, or treat directory/file existence as canonical processing state.

--- a/packages/ingestion/src/vlog_ingestion/__init__.py
+++ b/packages/ingestion/src/vlog_ingestion/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion boundary for Human Memory Repository v2."""
+
+from .inventory import InventoryBuilder, InventoryConfig, write_inventory
+
+__all__ = ["InventoryBuilder", "InventoryConfig", "write_inventory"]

--- a/packages/ingestion/src/vlog_ingestion/inventory.py
+++ b/packages/ingestion/src/vlog_ingestion/inventory.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+_DEFAULT_ROOTS = (
+    "data/recordings",
+    "data/transcripts",
+    "data/summaries",
+    "data/novels",
+    "data/photos",
+    "data/evaluations",
+    "data/manga",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryConfig:
+    repo_root: Path
+    evidence_roots: tuple[str, ...] = _DEFAULT_ROOTS
+    hash_chunk_bytes: int = 1024 * 1024
+
+    def __post_init__(self) -> None:
+        if not self.repo_root.is_absolute():
+            raise ValueError("repo_root must be absolute")
+        if self.hash_chunk_bytes <= 0:
+            raise ValueError("hash_chunk_bytes must be positive")
+        for root in self.evidence_roots:
+            candidate = Path(root)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                raise ValueError(f"evidence root must be repository-relative: {root}")
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryFile:
+    category: str
+    path: str
+    size_bytes: int
+    modified_at: str
+    sha256: str
+    tracked_by_git: bool
+    is_symlink: bool
+    link_target: str | None
+
+
+class InventoryBuilder:
+    """Build a read-only inventory of existing local evidence and artifacts."""
+
+    def __init__(self, config: InventoryConfig) -> None:
+        self.config = config
+
+    def build(self) -> dict[str, object]:
+        tracked = self._tracked_files()
+        records = sorted(
+            self._iter_records(tracked),
+            key=lambda record: (record.category, record.path),
+        )
+        duplicate_hashes = self._duplicate_hashes(records)
+        category_totals: dict[str, dict[str, int]] = {}
+        for record in records:
+            totals = category_totals.setdefault(
+                record.category,
+                {"files": 0, "bytes": 0, "tracked_files": 0},
+            )
+            totals["files"] += 1
+            totals["bytes"] += record.size_bytes
+            totals["tracked_files"] += int(record.tracked_by_git)
+
+        return {
+            "schema_version": "phase0-inventory-v1",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "repository": {
+                "root": str(self.config.repo_root),
+                "git_commit": self._git_commit(),
+            },
+            "policy": {
+                "operation": "read-only",
+                "deletes_files": False,
+                "moves_files": False,
+                "uploads_files": False,
+                "hash_algorithm": "sha256",
+            },
+            "roots": list(self.config.evidence_roots),
+            "summary": {
+                "files": len(records),
+                "bytes": sum(record.size_bytes for record in records),
+                "tracked_files": sum(record.tracked_by_git for record in records),
+                "categories": category_totals,
+                "duplicate_hash_groups": len(duplicate_hashes),
+            },
+            "duplicate_hashes": duplicate_hashes,
+            "files": [asdict(record) for record in records],
+        }
+
+    def _iter_records(self, tracked: set[str]) -> Iterable[InventoryFile]:
+        for relative_root in self.config.evidence_roots:
+            root = self.config.repo_root / relative_root
+            if not root.exists():
+                continue
+            category = Path(relative_root).name
+            for path in sorted(root.rglob("*")):
+                if path.is_dir():
+                    continue
+                relative_path = path.relative_to(self.config.repo_root).as_posix()
+                is_symlink = path.is_symlink()
+                link_target = os.readlink(path) if is_symlink else None
+                stat = path.lstat() if is_symlink else path.stat()
+                digest = self._hash_symlink(link_target) if is_symlink else self._sha256(path)
+                yield InventoryFile(
+                    category=category,
+                    path=relative_path,
+                    size_bytes=stat.st_size,
+                    modified_at=datetime.fromtimestamp(
+                        stat.st_mtime,
+                        tz=timezone.utc,
+                    ).isoformat(),
+                    sha256=digest,
+                    tracked_by_git=relative_path in tracked,
+                    is_symlink=is_symlink,
+                    link_target=link_target,
+                )
+
+    def _sha256(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(self.config.hash_chunk_bytes):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _hash_symlink(link_target: str | None) -> str:
+        return hashlib.sha256((link_target or "").encode("utf-8")).hexdigest()
+
+    def _tracked_files(self) -> set[str]:
+        result = subprocess.run(
+            ["git", "-C", str(self.config.repo_root), "ls-files", "-z"],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return set()
+        return {
+            item.decode("utf-8", errors="surrogateescape")
+            for item in result.stdout.split(b"\0")
+            if item
+        }
+
+    def _git_commit(self) -> str | None:
+        result = subprocess.run(
+            ["git", "-C", str(self.config.repo_root), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    @staticmethod
+    def _duplicate_hashes(records: list[InventoryFile]) -> list[dict[str, object]]:
+        by_hash: dict[str, list[str]] = {}
+        for record in records:
+            by_hash.setdefault(record.sha256, []).append(record.path)
+        return [
+            {"sha256": digest, "paths": sorted(paths)}
+            for digest, paths in sorted(by_hash.items())
+            if len(paths) > 1
+        ]
+
+
+def write_inventory(inventory: dict[str, object], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(f"{output.suffix}.tmp")
+    temporary.write_text(
+        json.dumps(inventory, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(output)

--- a/packages/memory-domain/README.md
+++ b/packages/memory-domain/README.md
@@ -1,0 +1,21 @@
+# memory-domain
+
+Storage-agnostic canonical entities for Human Memory Repository v2.
+
+## Owns
+
+- `SourceObject`, `Episode`, `Utterance`, `Moment`, and `Entity`
+- `MemoryClaim` and append-only `MemoryRevision`
+- generated `Artifact` metadata
+- explicit `PublicationDecision`
+- ingestion idempotency identity (`source_hash + pipeline_version`)
+
+## Does not own
+
+- filesystem or Supabase access
+- embeddings, Graphiti, Cognee, or Qdrant indexes
+- prompt templates and model clients
+- public web rendering
+- private journal content
+
+An accepted `MemoryClaim` cannot be constructed without provenance evidence. The domain package therefore makes the central v2 rule executable rather than documentary.

--- a/packages/memory-domain/src/vlog_memory_domain/__init__.py
+++ b/packages/memory-domain/src/vlog_memory_domain/__init__.py
@@ -1,0 +1,43 @@
+"""Canonical Human Memory Repository v2 domain model.
+
+This package contains storage-agnostic entities only. Persistence, retrieval,
+AI extraction, and publication are adapter concerns.
+"""
+
+from .models import (
+    Artifact,
+    ArtifactKind,
+    Entity,
+    Episode,
+    EvidenceRef,
+    IngestionRun,
+    IngestionStatus,
+    MemoryClaim,
+    MemoryRevision,
+    MemoryStatus,
+    Moment,
+    PrivacyLevel,
+    PublicationDecision,
+    SourceKind,
+    SourceObject,
+    Utterance,
+)
+
+__all__ = [
+    "Artifact",
+    "ArtifactKind",
+    "Entity",
+    "Episode",
+    "EvidenceRef",
+    "IngestionRun",
+    "IngestionStatus",
+    "MemoryClaim",
+    "MemoryRevision",
+    "MemoryStatus",
+    "Moment",
+    "PrivacyLevel",
+    "PublicationDecision",
+    "SourceKind",
+    "SourceObject",
+    "Utterance",
+]

--- a/packages/memory-domain/src/vlog_memory_domain/models.py
+++ b/packages/memory-domain/src/vlog_memory_domain/models.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Mapping
+from uuid import UUID, uuid4
+
+
+def _new_id() -> str:
+    return str(uuid4())
+
+
+def _validate_id(value: str, field_name: str) -> None:
+    try:
+        UUID(value)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"{field_name} must be a UUID string") from exc
+
+
+def _validate_aware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+class PrivacyLevel(StrEnum):
+    PRIVATE = "private"
+    SENSITIVE = "sensitive"
+    INTERNAL = "internal"
+    PUBLIC = "public"
+
+
+class SourceKind(StrEnum):
+    AUDIO = "audio"
+    PHOTO = "photo"
+    VIDEO = "video"
+    TRANSCRIPT = "transcript"
+    CONVERSATION = "conversation"
+    DOCUMENT = "document"
+
+
+class MemoryStatus(StrEnum):
+    CANDIDATE = "candidate"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+    FORGOTTEN = "forgotten"
+
+
+class IngestionStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class ArtifactKind(StrEnum):
+    DIARY = "diary"
+    NOVEL = "novel"
+    ILLUSTRATION = "illustration"
+    MONTHLY_REVIEW = "monthly_review"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """A precise, immutable pointer from a memory claim to its evidence."""
+
+    source_object_id: str
+    episode_id: str
+    utterance_id: str | None = None
+    start_ms: int | None = None
+    end_ms: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_id(self.source_object_id, "source_object_id")
+        _validate_id(self.episode_id, "episode_id")
+        if self.utterance_id is not None:
+            _validate_id(self.utterance_id, "utterance_id")
+        if (self.start_ms is None) != (self.end_ms is None):
+            raise ValueError("start_ms and end_ms must be provided together")
+        if self.start_ms is not None:
+            if self.start_ms < 0 or self.end_ms is None or self.end_ms < self.start_ms:
+                raise ValueError("evidence time range is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class SourceObject:
+    kind: SourceKind
+    object_uri: str
+    sha256: str
+    size_bytes: int
+    recorded_at: datetime
+    privacy: PrivacyLevel = PrivacyLevel.PRIVATE
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_aware(self.recorded_at, "recorded_at")
+        if not self.object_uri.startswith("private://") and self.privacy is not PrivacyLevel.PUBLIC:
+            raise ValueError("non-public source objects must use a private:// object URI")
+        if len(self.sha256) != 64 or any(ch not in "0123456789abcdef" for ch in self.sha256.lower()):
+            raise ValueError("sha256 must be a 64-character hexadecimal digest")
+        if self.size_bytes < 0:
+            raise ValueError("size_bytes must not be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class Episode:
+    started_at: datetime
+    ended_at: datetime
+    source_object_ids: tuple[str, ...]
+    title: str | None = None
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_aware(self.started_at, "started_at")
+        _validate_aware(self.ended_at, "ended_at")
+        if self.ended_at < self.started_at:
+            raise ValueError("ended_at must not precede started_at")
+        if not self.source_object_ids:
+            raise ValueError("an episode must reference at least one source object")
+        for source_id in self.source_object_ids:
+            _validate_id(source_id, "source_object_ids")
+
+
+@dataclass(frozen=True, slots=True)
+class Utterance:
+    episode_id: str
+    started_at: datetime
+    ended_at: datetime
+    text: str
+    speaker_entity_id: str | None = None
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.episode_id, "episode_id")
+        if self.speaker_entity_id is not None:
+            _validate_id(self.speaker_entity_id, "speaker_entity_id")
+        _validate_aware(self.started_at, "started_at")
+        _validate_aware(self.ended_at, "ended_at")
+        if self.ended_at < self.started_at:
+            raise ValueError("ended_at must not precede started_at")
+        if not self.text.strip():
+            raise ValueError("utterance text must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class Moment:
+    episode_id: str
+    summary: str
+    evidence: tuple[EvidenceRef, ...]
+    importance: float = 0.5
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.episode_id, "episode_id")
+        if not self.summary.strip():
+            raise ValueError("moment summary must not be empty")
+        if not self.evidence:
+            raise ValueError("a moment must retain evidence")
+        if not 0.0 <= self.importance <= 1.0:
+            raise ValueError("importance must be between 0 and 1")
+
+
+@dataclass(frozen=True, slots=True)
+class Entity:
+    entity_type: str
+    canonical_name: str
+    aliases: tuple[str, ...] = ()
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        if not self.entity_type.strip():
+            raise ValueError("entity_type must not be empty")
+        if not self.canonical_name.strip():
+            raise ValueError("canonical_name must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryClaim:
+    claim_type: str
+    subject_entity_id: str
+    value: Any
+    valid_from: datetime
+    evidence: tuple[EvidenceRef, ...]
+    status: MemoryStatus = MemoryStatus.CANDIDATE
+    valid_to: datetime | None = None
+    confidence: float = 0.5
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.subject_entity_id, "subject_entity_id")
+        _validate_aware(self.valid_from, "valid_from")
+        if self.valid_to is not None:
+            _validate_aware(self.valid_to, "valid_to")
+            if self.valid_to < self.valid_from:
+                raise ValueError("valid_to must not precede valid_from")
+        if not self.claim_type.strip():
+            raise ValueError("claim_type must not be empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        if self.status is MemoryStatus.ACCEPTED and not self.evidence:
+            raise ValueError("accepted memory claims require provenance evidence")
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRevision:
+    claim_id: str
+    previous_status: MemoryStatus
+    new_status: MemoryStatus
+    reason: str
+    revised_at: datetime
+    evidence: tuple[EvidenceRef, ...] = ()
+    supersedes_revision_id: str | None = None
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.claim_id, "claim_id")
+        if self.supersedes_revision_id is not None:
+            _validate_id(self.supersedes_revision_id, "supersedes_revision_id")
+        _validate_aware(self.revised_at, "revised_at")
+        if not self.reason.strip():
+            raise ValueError("revision reason must not be empty")
+        if self.new_status is MemoryStatus.ACCEPTED and not self.evidence:
+            raise ValueError("accepting a claim requires provenance evidence")
+
+
+@dataclass(frozen=True, slots=True)
+class Artifact:
+    kind: ArtifactKind
+    generated_at: datetime
+    source_episode_ids: tuple[str, ...]
+    source_claim_ids: tuple[str, ...]
+    content_uri: str
+    generator_version: str
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_aware(self.generated_at, "generated_at")
+        if not self.source_episode_ids and not self.source_claim_ids:
+            raise ValueError("an artifact must reference canonical memory or evidence")
+        for episode_id in self.source_episode_ids:
+            _validate_id(episode_id, "source_episode_ids")
+        for claim_id in self.source_claim_ids:
+            _validate_id(claim_id, "source_claim_ids")
+        if not self.content_uri.strip():
+            raise ValueError("content_uri must not be empty")
+        if not self.generator_version.strip():
+            raise ValueError("generator_version must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class IngestionRun:
+    source_hash: str
+    pipeline_version: str
+    status: IngestionStatus
+    started_at: datetime
+    completed_at: datetime | None = None
+    error: str | None = None
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_aware(self.started_at, "started_at")
+        if self.completed_at is not None:
+            _validate_aware(self.completed_at, "completed_at")
+            if self.completed_at < self.started_at:
+                raise ValueError("completed_at must not precede started_at")
+        if not self.source_hash.strip() or not self.pipeline_version.strip():
+            raise ValueError("source_hash and pipeline_version are required")
+        if self.status is IngestionStatus.FAILED and not self.error:
+            raise ValueError("failed ingestion runs require an error")
+
+    @property
+    def idempotency_key(self) -> str:
+        return f"{self.source_hash}:{self.pipeline_version}"
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationDecision:
+    artifact_id: str
+    approved: bool
+    decided_at: datetime
+    decided_by: str
+    rationale: str
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.artifact_id, "artifact_id")
+        _validate_aware(self.decided_at, "decided_at")
+        if not self.decided_by.strip():
+            raise ValueError("decided_by must not be empty")
+        if not self.rationale.strip():
+            raise ValueError("publication decisions require an explicit rationale")

--- a/packages/narrative/README.md
+++ b/packages/narrative/README.md
@@ -1,0 +1,5 @@
+# narrative
+
+Generation policies and use cases for diaries, novels, illustrations, and periodic reviews.
+
+Narrative output is always an `Artifact` derived from canonical episode/claim IDs. Deleting a generated artifact must not delete its evidence or canonical memory.

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,0 +1,5 @@
+# observability
+
+Operational events, traces, health checks, inventory audit records, and recovery evidence.
+
+Observability data must avoid raw private evidence and secrets. It may identify a source by opaque ID/hash, but must not become an alternate copy of personal content.

--- a/packages/privacy/README.md
+++ b/packages/privacy/README.md
@@ -1,0 +1,5 @@
+# privacy
+
+Redaction, pseudonymization, retention, evidence access, and publication-gate policies.
+
+Private-by-default is enforced here and in PostgreSQL/Storage policy. Application code alone is not a sufficient privacy boundary.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,5 @@
+# Schemas
+
+Versioned interchange contracts for evidence manifests, canonical memory, and generated artifacts.
+
+Schemas are intentionally independent from PostgreSQL table layout and vendor SDKs. Breaking changes require a new schema version and an ADR.

--- a/schemas/diary-frontmatter.schema.json
+++ b/schemas/diary-frontmatter.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/vlog/schemas/diary-frontmatter.schema.json",
+  "title": "Human Memory v2 Diary Frontmatter",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_id",
+    "date",
+    "generated_at",
+    "generator_version",
+    "source_episode_ids",
+    "source_claim_ids",
+    "publication_status"
+  ],
+  "properties": {
+    "artifact_id": {"type": "string", "format": "uuid"},
+    "date": {"type": "string", "format": "date"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "generator_version": {"type": "string", "minLength": 1},
+    "source_episode_ids": {
+      "type": "array",
+      "items": {"type": "string", "format": "uuid"}
+    },
+    "source_claim_ids": {
+      "type": "array",
+      "items": {"type": "string", "format": "uuid"}
+    },
+    "publication_status": {
+      "type": "string",
+      "enum": ["private", "review_required", "approved", "rejected", "withdrawn"]
+    },
+    "publication_decision_id": {"type": ["string", "null"], "format": "uuid"},
+    "style_revision": {"type": ["string", "null"]}
+  },
+  "anyOf": [
+    {"properties": {"source_episode_ids": {"minItems": 1}}},
+    {"properties": {"source_claim_ids": {"minItems": 1}}}
+  ]
+}

--- a/schemas/episode.schema.json
+++ b/schemas/episode.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/vlog/schemas/episode.schema.json",
+  "title": "Human Memory v2 Episode",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "started_at", "ended_at", "source_object_ids"],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "title": {"type": ["string", "null"]},
+    "started_at": {"type": "string", "format": "date-time"},
+    "ended_at": {"type": "string", "format": "date-time"},
+    "source_object_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "format": "uuid"}
+    },
+    "entity_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "format": "uuid"}
+    },
+    "metadata": {"type": "object"}
+  }
+}

--- a/schemas/memory-claim.schema.json
+++ b/schemas/memory-claim.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/vlog/schemas/memory-claim.schema.json",
+  "title": "Human Memory v2 Memory Claim",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "claim_type",
+    "subject_entity_id",
+    "value",
+    "valid_from",
+    "status",
+    "confidence",
+    "evidence"
+  ],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "claim_type": {"type": "string", "minLength": 1},
+    "subject_entity_id": {"type": "string", "format": "uuid"},
+    "value": true,
+    "valid_from": {"type": "string", "format": "date-time"},
+    "valid_to": {"type": ["string", "null"], "format": "date-time"},
+    "status": {
+      "type": "string",
+      "enum": ["candidate", "accepted", "rejected", "superseded", "forgotten"]
+    },
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidenceRef"}
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "accepted"}}, "required": ["status"]},
+      "then": {"properties": {"evidence": {"minItems": 1}}}
+    }
+  ],
+  "$defs": {
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_object_id", "episode_id"],
+      "properties": {
+        "source_object_id": {"type": "string", "format": "uuid"},
+        "episode_id": {"type": "string", "format": "uuid"},
+        "utterance_id": {"type": ["string", "null"], "format": "uuid"},
+        "start_ms": {"type": ["integer", "null"], "minimum": 0},
+        "end_ms": {"type": ["integer", "null"], "minimum": 0}
+      }
+    }
+  }
+}

--- a/schemas/source-manifest.schema.json
+++ b/schemas/source-manifest.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/vlog/schemas/source-manifest.schema.json",
+  "title": "Human Memory v2 Source Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "kind",
+    "object_uri",
+    "sha256",
+    "size_bytes",
+    "recorded_at",
+    "privacy"
+  ],
+  "properties": {
+    "id": {"type": "string", "format": "uuid"},
+    "kind": {
+      "type": "string",
+      "enum": ["audio", "photo", "video", "transcript", "conversation", "document"]
+    },
+    "object_uri": {"type": "string", "pattern": "^private://[^/]+/.+"},
+    "sha256": {"type": "string", "pattern": "^[A-Fa-f0-9]{64}$"},
+    "size_bytes": {"type": "integer", "minimum": 0},
+    "recorded_at": {"type": "string", "format": "date-time"},
+    "privacy": {
+      "type": "string",
+      "enum": ["private", "sensitive", "internal", "public"]
+    },
+    "media_type": {"type": ["string", "null"]},
+    "original_filename": {"type": ["string", "null"]},
+    "metadata": {"type": "object"}
+  }
+}

--- a/scripts/check_repository_boundaries.py
+++ b/scripts/check_repository_boundaries.py
@@ -112,18 +112,6 @@ def check(root: Path) -> list[Violation]:
                     "tracked file exceeds GitHub's 100 MiB file limit",
                 ),
             )
-        if path.is_symlink():
-            target = path.resolve(strict=False)
-            try:
-                target.relative_to(root)
-            except ValueError:
-                violations.append(
-                    Violation(
-                        "escaping-symlink",
-                        relative,
-                        "tracked symlink resolves outside the repository",
-                    ),
-                )
 
     return violations
 

--- a/scripts/check_repository_boundaries.py
+++ b/scripts/check_repository_boundaries.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_PATHS = (
+    "apps",
+    "packages",
+    "packages/memory-domain",
+    "packages/ingestion",
+    "adapters",
+    "infra",
+    "schemas",
+    "docs/architecture",
+    "docs/operations",
+)
+PRIVATE_ROOTS = (
+    "journal/",
+    "memory/people/",
+    "memory/relationships/",
+    "memory/self/",
+    "feedback/",
+    "sources/",
+)
+RAW_MEDIA_SUFFIXES = {
+    ".wav",
+    ".flac",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".ogg",
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".mkv",
+}
+MAX_GIT_FILE_BYTES = 100 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class Violation:
+    code: str
+    path: str
+    message: str
+
+
+def tracked_files(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return sorted(
+        item.decode("utf-8", errors="surrogateescape")
+        for item in result.stdout.split(b"\0")
+        if item
+    )
+
+
+def check(root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    tracked = tracked_files(root)
+
+    for required in REQUIRED_PATHS:
+        if not (root / required).exists():
+            violations.append(
+                Violation("missing-boundary", required, "required v2 boundary is absent"),
+            )
+
+    agents = root / "AGENTS.md"
+    if agents.exists():
+        text = agents.read_text(encoding="utf-8")
+        for forbidden in ("file://", "/home/kafka/", "\\home\\kafka\\"):
+            if forbidden in text:
+                violations.append(
+                    Violation(
+                        "non-portable-agent-pointer",
+                        "AGENTS.md",
+                        f"contains forbidden absolute pointer: {forbidden}",
+                    ),
+                )
+
+    for relative in tracked:
+        normalized = relative.replace("\\", "/")
+        path = root / relative
+        if any(normalized.startswith(prefix) for prefix in PRIVATE_ROOTS):
+            violations.append(
+                Violation(
+                    "private-memory-in-public-repo",
+                    relative,
+                    "private memory belongs in kafka-memory, not vlog",
+                ),
+            )
+        if path.suffix.lower() in RAW_MEDIA_SUFFIXES:
+            violations.append(
+                Violation(
+                    "raw-media-tracked",
+                    relative,
+                    "raw audio/video must be stored in private object storage",
+                ),
+            )
+        if path.is_file() and not path.is_symlink() and path.stat().st_size > MAX_GIT_FILE_BYTES:
+            violations.append(
+                Violation(
+                    "oversized-git-object",
+                    relative,
+                    "tracked file exceeds GitHub's 100 MiB file limit",
+                ),
+            )
+        if path.is_symlink():
+            target = path.resolve(strict=False)
+            try:
+                target.relative_to(root)
+            except ValueError:
+                violations.append(
+                    Violation(
+                        "escaping-symlink",
+                        relative,
+                        "tracked symlink resolves outside the repository",
+                    ),
+                )
+
+    return violations
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate Human Memory v2 boundaries.")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.expanduser().resolve()
+    violations = check(root)
+    if not violations:
+        print("Repository boundary check passed.")
+        return 0
+
+    for violation in violations:
+        print(
+            f"{violation.code}: {violation.path}: {violation.message}",
+            file=sys.stderr,
+        )
+    print(f"Boundary check failed with {len(violations)} violation(s).", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_repository_boundaries.py
+++ b/scripts/check_repository_boundaries.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -39,6 +40,11 @@ RAW_MEDIA_SUFFIXES = {
     ".avi",
     ".mkv",
 }
+NON_PORTABLE_AGENT_LINKS = (
+    re.compile(r"\]\(file://[^)]*\)"),
+    re.compile(r"\]\(/home/[^)]*\)"),
+    re.compile(r"\]\([A-Za-z]:\\[^)]*\)"),
+)
 MAX_GIT_FILE_BYTES = 100 * 1024 * 1024
 
 
@@ -75,13 +81,14 @@ def check(root: Path) -> list[Violation]:
     agents = root / "AGENTS.md"
     if agents.exists():
         text = agents.read_text(encoding="utf-8")
-        for forbidden in ("file://", "/home/kafka/", "\\home\\kafka\\"):
-            if forbidden in text:
+        for pattern in NON_PORTABLE_AGENT_LINKS:
+            match = pattern.search(text)
+            if match:
                 violations.append(
                     Violation(
                         "non-portable-agent-pointer",
                         "AGENTS.md",
-                        f"contains forbidden absolute pointer: {forbidden}",
+                        f"contains non-portable Markdown link: {match.group(0)}",
                     ),
                 )
 

--- a/scripts/phase0_inventory.py
+++ b/scripts/phase0_inventory.py
@@ -11,7 +11,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 INGESTION_SRC = REPO_ROOT / "packages" / "ingestion" / "src"
 sys.path.insert(0, str(INGESTION_SRC))
 
-from vlog_ingestion import InventoryBuilder, InventoryConfig, write_inventory  # noqa: E402
+from vlog_ingestion import (  # noqa: E402
+    InventoryBuilder,
+    InventoryConfig,
+    write_inventory,
+)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/phase0_inventory.py
+++ b/scripts/phase0_inventory.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INGESTION_SRC = REPO_ROOT / "packages" / "ingestion" / "src"
+sys.path.insert(0, str(INGESTION_SRC))
+
+from vlog_ingestion import InventoryBuilder, InventoryConfig, write_inventory  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a read-only inventory before Human Memory v2 migration.",
+    )
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output path. Defaults to data/inventory/phase0-<UTC timestamp>.json.",
+    )
+    parser.add_argument(
+        "--evidence-root",
+        action="append",
+        dest="evidence_roots",
+        help="Repository-relative root to inventory. Repeat to override defaults.",
+    )
+    parser.add_argument(
+        "--fail-on-tracked-evidence",
+        action="store_true",
+        help="Exit 2 when evidence files are tracked by Git.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.expanduser().resolve()
+    config_kwargs: dict[str, object] = {"repo_root": root}
+    if args.evidence_roots:
+        config_kwargs["evidence_roots"] = tuple(args.evidence_roots)
+    inventory = InventoryBuilder(InventoryConfig(**config_kwargs)).build()
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output = args.output or root / "data" / "inventory" / f"phase0-{timestamp}.json"
+    output = output if output.is_absolute() else root / output
+    write_inventory(inventory, output)
+
+    summary = inventory["summary"]
+    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"Inventory: {output}")
+    print("No files were deleted, moved, or uploaded.")
+
+    tracked_files = int(summary["tracked_files"])
+    if args.fail_on_tracked_evidence and tracked_files:
+        print(f"ERROR: {tracked_files} evidence files are tracked by Git.", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_memory_domain_v2.py
+++ b/tests/test_memory_domain_v2.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "packages" / "memory-domain" / "src"))
+
+from vlog_memory_domain import (  # noqa: E402
+    EvidenceRef,
+    IngestionRun,
+    IngestionStatus,
+    MemoryClaim,
+    MemoryStatus,
+    PrivacyLevel,
+    SourceKind,
+    SourceObject,
+)
+
+
+def test_accepted_claim_requires_provenance() -> None:
+    with pytest.raises(ValueError, match="require provenance"):
+        MemoryClaim(
+            claim_type="preference",
+            subject_entity_id=str(uuid4()),
+            value="quiet hotels",
+            valid_from=datetime.now(timezone.utc),
+            evidence=(),
+            status=MemoryStatus.ACCEPTED,
+        )
+
+
+def test_accepted_claim_retains_episode_and_source_reference() -> None:
+    evidence = EvidenceRef(
+        source_object_id=str(uuid4()),
+        episode_id=str(uuid4()),
+        utterance_id=str(uuid4()),
+        start_ms=1200,
+        end_ms=4300,
+    )
+    claim = MemoryClaim(
+        claim_type="open_loop",
+        subject_entity_id=str(uuid4()),
+        value={"task": "confirm booking"},
+        valid_from=datetime.now(timezone.utc),
+        evidence=(evidence,),
+        status=MemoryStatus.ACCEPTED,
+        confidence=0.9,
+    )
+
+    assert claim.evidence == (evidence,)
+    assert claim.status is MemoryStatus.ACCEPTED
+
+
+def test_private_source_requires_private_object_uri() -> None:
+    with pytest.raises(ValueError, match="private://"):
+        SourceObject(
+            kind=SourceKind.AUDIO,
+            object_uri="https://example.invalid/session.flac",
+            sha256="0" * 64,
+            size_bytes=123,
+            recorded_at=datetime.now(timezone.utc),
+            privacy=PrivacyLevel.PRIVATE,
+        )
+
+
+def test_ingestion_idempotency_key_includes_pipeline_version() -> None:
+    run = IngestionRun(
+        source_hash="abc123",
+        pipeline_version="memory-v2.0.1",
+        status=IngestionStatus.SUCCEEDED,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+
+    assert run.idempotency_key == "abc123:memory-v2.0.1"

--- a/tests/test_phase0_inventory.py
+++ b/tests/test_phase0_inventory.py
@@ -7,7 +7,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "packages" / "ingestion" / "src"))
 
-from vlog_ingestion import InventoryBuilder, InventoryConfig, write_inventory  # noqa: E402
+from vlog_ingestion import (  # noqa: E402
+    InventoryBuilder,
+    InventoryConfig,
+    write_inventory,
+)
 
 
 def test_inventory_hashes_files_without_modifying_sources(tmp_path: Path) -> None:

--- a/tests/test_phase0_inventory.py
+++ b/tests/test_phase0_inventory.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "packages" / "ingestion" / "src"))
+
+from vlog_ingestion import InventoryBuilder, InventoryConfig, write_inventory  # noqa: E402
+
+
+def test_inventory_hashes_files_without_modifying_sources(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    recordings = tmp_path / "data" / "recordings"
+    recordings.mkdir(parents=True)
+    source = recordings / "session.flac"
+    source.write_bytes(b"evidence")
+    before = source.stat()
+
+    inventory = InventoryBuilder(InventoryConfig(repo_root=tmp_path)).build()
+    output = tmp_path / "data" / "inventory" / "phase0.json"
+    write_inventory(inventory, output)
+
+    after = source.stat()
+    assert source.read_bytes() == b"evidence"
+    assert before.st_size == after.st_size
+    assert inventory["policy"] == {
+        "operation": "read-only",
+        "deletes_files": False,
+        "moves_files": False,
+        "uploads_files": False,
+        "hash_algorithm": "sha256",
+    }
+    assert inventory["summary"]["files"] == 1
+    assert inventory["files"][0]["path"] == "data/recordings/session.flac"
+    assert len(inventory["files"][0]["sha256"]) == 64
+    assert output.exists()
+
+
+def test_inventory_reports_duplicate_content(tmp_path: Path) -> None:
+    first_root = tmp_path / "data" / "recordings"
+    second_root = tmp_path / "data" / "transcripts"
+    first_root.mkdir(parents=True)
+    second_root.mkdir(parents=True)
+    (first_root / "a.flac").write_bytes(b"same")
+    (second_root / "a.txt").write_bytes(b"same")
+
+    inventory = InventoryBuilder(InventoryConfig(repo_root=tmp_path)).build()
+
+    assert inventory["summary"]["duplicate_hash_groups"] == 1
+    assert inventory["duplicate_hashes"][0]["paths"] == [
+        "data/recordings/a.flac",
+        "data/transcripts/a.txt",
+    ]


### PR DESCRIPTION
## Summary

Implements the non-destructive foundation of Issue #14 before relocating the live runtime.

- establishes `apps/`, `packages/`, `adapters/`, `infra/`, and `schemas/` boundaries;
- adds storage-agnostic v2 domain entities and executable provenance invariants;
- prevents an `accepted` memory claim without evidence;
- adds read-only SHA-256 inventory tooling for legacy evidence/artifacts;
- records Git tracking, byte totals, duplicate hashes, symlinks, and current commit;
- adds versioned source, episode, claim, and diary frontmatter schemas;
- replaces user-specific `file://` pointers in `AGENTS.md` with portable repository links;
- adds CI enforcement for public/private repository boundaries;
- reframes README and architecture docs around Evidence -> Human Memory -> Narrative -> Public Projection.

## Safety

This PR does **not** delete, move, upload, or rewrite raw evidence. It does not relocate the current `src/`, `frontend/reader/`, systemd, or Windows runtime yet. Those moves belong in the next behavior-preserving migration PR after this gate is green and the operating environment inventory is retained.

## Verification

CI now runs:

- Python compile for `src`, `packages`, `scripts`, and `tests`;
- Ruff across the same boundaries;
- `scripts/check_repository_boundaries.py`;
- the full pytest suite, including new domain and inventory tests.

## Follow-up

1. Run `scripts/phase0_inventory.py` in the real operating environment.
2. Export Supabase schema, rows, buckets, paginated object manifests, and RLS/Storage policies.
3. Relocate runtime code, reader, systemd, and Windows assets without behavior changes.
4. Only then remove legacy locations.

Advances #14.