### PR TITLE
READMEをHuman Memory v2の日本語正準文書へ刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,148 @@
 # VLog Human Memory Engine
 
-VLog is a public OSS engine for capturing VRChat evidence, producing reviewable memory claims and narrative artifacts, and publishing only explicitly approved projections.
+VLogは、VRChatで生じた音声、写真、会話、出来事を証拠として保存し、人間が確認できる記憶、日記、物語、公開物へ段階的に変換するための公開OSSエンジンです。
 
-Human Memory Repository v2 is an active migration tracked in [Issue #14](https://github.com/KAFKA2306/vlog/issues/14). The repository boundaries and behavior-preserving runtime relocation are implemented. Canonical persistence, private memory, private object-storage migration, and retrieval remain incomplete.
+このリポジトリの目的は、録音から日記を自動生成することだけではありません。**原証拠、人間の記憶、AIが生成した物語、公開物を別の層として扱い、根拠、訂正、非公開境界、公開判断を追跡できるHuman Memory Repository**へ移行しています。
 
-## Architecture
+> **現在の大きな移行:** Human Memory Repository v2  
+> **進捗の正準:** [Issue #14](https://github.com/KAFKA2306/vlog/issues/14)  
+> **公開OSS:** エンジン、schema、移行tool、運用tool、reader  
+> **公開しないもの:** 私的な記憶、原音声、写真、会話全文、個人情報  
+> **Python:** 3.11以上  
+> **主要操作:** `uv` / Task / Bun
+
+---
+
+## Human Memory v2の考え方
 
 ```text
 Evidence
-raw audio, photos, conversations, full transcripts
-        ↓
+原音声、写真、会話、全文文字起こし
+        │
+        ▼
 Human Memory
-episodes, moments, entities, claims, revisions
-        ↓
-Narrative Artifacts
-diaries, novels, illustrations, monthly reviews
-        ↓
+episode、moment、entity、claim、revision
+        │
+        ▼
+Narrative Artifact
+日記、小説、イラスト、月次振り返り
+        │
+        ▼
 Public Projection
-explicitly approved artifacts only
+明示的に公開を承認した成果物だけ
 ```
 
-Diaries, novels, illustrations, summaries, graph indexes, and vector indexes are derived views. They are not canonical memory. An accepted `MemoryClaim` requires provenance to source evidence.
+日記、小説、イラスト、要約、graph index、vector indexは、原記憶そのものではなく再生成可能なviewです。
 
-## Current status
+`MemoryClaim`をacceptedにするには、source evidenceへの来歴が必要です。AIが文章を生成したという理由だけでは、人間の記憶として確定しません。
 
-| Area | Status |
+訂正では過去値を破壊せず、revisionを追加します。公開は、記憶の採用とは別の判断です。
+
+---
+
+## 現在の状態
+
+| 領域 | 状態 |
 |---|---|
-| `apps/`, `packages/`, `adapters/`, `infra/`, `schemas/` boundaries | implemented in repository |
-| Canonical domain models and provenance invariant | implemented in repository |
-| Read-only SHA-256 Phase 0 inventory tooling | implemented in repository; production inventory not yet executed |
-| Runtime relocation to `apps/capture-vrchat/` and `apps/reader/` | implemented in repository |
-| Portable systemd, Windows, and Supabase paths | implemented in repository; host cutover not yet verified |
-| Private `kafka-memory` repository | planned |
-| Canonical PostgreSQL schema, UUIDs, idempotency, and outbox | planned |
-| Private object-storage migration and complete manifests | planned |
-| Hybrid retrieval and read-first MCP | planned |
-| Legacy file-state removal | planned after migration reconciliation |
+| `apps/`、`packages/`、`adapters/`、`infra/`、`schemas/`の境界 | リポジトリへ実装済み |
+| Episode、MemoryClaim、MemoryRevision、Artifactなどのdomain model | 実装済み |
+| 根拠なしaccepted claimの禁止 | 実装済み |
+| SHA-256付きread-only Phase 0 inventory | tool実装済み。production inventoryは未実行 |
+| capture runtimeとreaderの新directoryへの移動 | 実装済み |
+| portable systemd、Windows、Supabase path | リポジトリへ実装済み。実hostの切替は未検証 |
+| private memory repository | 設計済み・未構築 |
+| canonical PostgreSQL schema、UUID、idempotency、outbox | 未実装 |
+| private object storageへの完全移行 | 未実装 |
+| hybrid retrievalとread-first MCP | 未実装 |
+| legacy file-stateの撤去 | 移行照合後に実施予定 |
 
-GitHub CI validates repository behavior. It does not prove live systemd installation, Windows Task Scheduler behavior, Vercel configuration, Supabase contents or policies, private storage, or GPU execution.
+GitHub CIが成功しても、次を証明しません。
 
-## Repository boundaries
+- 実hostのsystemd unitが有効化されている
+- Windows Task Schedulerが稼働している
+- Vercel設定が正しい
+- Supabaseの実データとRLSが正しい
+- private object storageへ全証拠が移行済み
+- GPU文字起こしが動作する
+
+---
+
+## 公開・非公開境界
+
+```text
+KAFKA2306/vlog
+  公開OSSエンジン、schema、reader、運用・移行tool
+
+private memory repository
+  人間が確認した記憶、日記view、訂正、公開policy
+
+private object storage
+  原音声、写真、動画、全文証拠
+
+public site
+  明示的に承認したprojectionだけ
+```
+
+公開リポジトリへ、個人の原音声、会話全文、非公開写真、位置情報、関係者の個人情報を保存しません。
+
+公開する場合も、Evidenceを直接公開するのではなく、公開判断を持つArtifactまたはProjectionを経由します。
+
+---
+
+## リポジトリ構造
 
 ```text
 vlog/
 ├── apps/
-│   ├── capture-vrchat/   current Python capture and processing runtime
-│   ├── reader/           current Next.js reader
-│   ├── api/              reserved HTTP application boundary
-│   └── mcp/              reserved read-first MCP boundary
-├── packages/             storage-agnostic domain capabilities
-├── adapters/             persistence, graph, vector, and storage integrations
+│   ├── capture-vrchat/   現在のPython録音・処理runtime
+│   ├── reader/           現在のNext.js reader
+│   ├── api/              将来のHTTP application境界
+│   └── mcp/              将来のread-first MCP境界
+├── packages/             storageに依存しないdomain capability
+├── adapters/             persistence、graph、vector、storage接続
 ├── infra/
-│   ├── supabase/         current schema and migrations
-│   ├── systemd/          portable unit templates and installer
-│   └── windows/          Task Scheduler, bootstrap, and watchdog assets
-├── schemas/              versioned interchange contracts
-├── docs/                 architecture, ADRs, and operations
+│   ├── supabase/         現在のschemaとmigration
+│   ├── systemd/          portable unit templateとinstaller
+│   └── windows/          Task Scheduler、bootstrap、watchdog
+├── schemas/              version付きinterchange contract
+├── docs/                 architecture、ADR、operations
 ├── tests/                repository-level verification
-└── data/                 machine-local evidence and generated artifacts
+└── data/                 machine-local evidenceと生成物。原則Git管理外
 ```
 
-Private personal data is deliberately outside this public repository:
+Python import package名は、runtime移行中の互換性維持のため現在も`src`です。`Taskfile.yaml`、CI、systemd template、Windows scriptは`apps/capture-vrchat`をruntime rootとして設定します。
 
-```text
-KAFKA2306/vlog             public OSS engine
-KAFKA2306/kafka-memory     private reviewed memory and journal views
-private object storage     raw audio, photos, video, and full evidence
-public site                explicitly approved projections only
-```
+---
 
-## Current runtime
+## 現行runtime
 
-The relocated runtime preserves existing behavior while the v2 persistence model is built:
+Human Memory v2のcanonical persistenceを構築している間、現在のruntime動作は維持されています。
 
-- VRChat process monitoring and audio capture;
-- transcription and generated diary/narrative artifacts;
-- file-based processing state and directory scans;
-- Supabase synchronization and the Next.js reader;
-- systemd and Windows supervision assets;
-- operational audit and recovery tooling.
+- VRChat processの監視
+- 音声録音
+- 文字起こし
+- 日記・物語・画像などの生成
+- file existenceとdirectory scanによる処理状態
+- Supabase同期
+- Next.js reader
+- systemdとWindows supervision
+- 運用監査と復旧tool
 
-The Python import package intentionally remains named `src`. `Taskfile.yaml`, CI, systemd templates, and Windows scripts set the runtime path to `apps/capture-vrchat`.
+これらのうち、file-based processing stateやdirectory scanはlegacy mechanismです。v2の最終状態では、canonical ingestion stateとoutboxへ移行します。
 
-## Setup
+---
 
-Requirements: Python 3.11+, [`uv`](https://github.com/astral-sh/uv), and [Task](https://taskfile.dev). Reader commands additionally require Bun.
+## セットアップ
+
+### 必要環境
+
+- Python 3.11以上
+- [`uv`](https://github.com/astral-sh/uv)
+- [Task](https://taskfile.dev)
+- readerを扱う場合はBun
+- 実録音・文字起こしでは対応する音声device、VRChat、モデル、認証情報
+
+### 初期化
 
 ```bash
 git clone https://github.com/KAFKA2306/vlog.git
@@ -93,55 +151,219 @@ uv sync --frozen
 cp .env.example .env
 ```
 
-Common commands:
+`.env`へ実値を設定します。APIキー、Supabase key、秘密のstorage情報をcommitしません。
+
+---
+
+## 主なコマンド
+
+### 開発
 
 ```bash
 task dev
+```
+
+### テスト
+
+```bash
 task test
+```
+
+### Markdown・文書契約
+
+```bash
 task doc:check
+```
+
+### systemd template検証
+
+```bash
 task systemd:verify
+```
+
+### reader build
+
+```bash
 task web:build
 ```
 
-Operational commands such as `task up`, `task status`, `task sync`, and `task web:deploy` require their corresponding host credentials and services.
+### host操作を伴うコマンド
 
-## Before data migration
+```bash
+task up
+task status
+task sync
+task web:deploy
+```
 
-Create a non-destructive inventory before relocating or deleting any legacy evidence:
+これらは、対応するhost、service、credentialが必要です。コマンドが存在することだけで、production運用が有効とは判断しません。
+
+利用可能なtaskと実行内容は`Taskfile.yaml`を確認してください。
+
+---
+
+## 移行前のinventory
+
+legacy evidenceを移動、削除、uploadする前に、非破壊inventoryを作成します。
 
 ```bash
 uv run --no-sync python scripts/phase0_inventory.py
 uv run --no-sync python scripts/check_repository_boundaries.py
 ```
 
-The inventory records file counts, bytes, hashes, Git tracking state, duplicate content, and the current commit. It does not delete, move, upload, or rewrite evidence.
+inventoryは次を記録します。
 
-## Canonical rules
+- file count
+- byte size
+- SHA-256
+- Git tracking状態
+- duplicate content
+- 現在のcommit
 
-- Private object storage is canonical for raw evidence bytes.
-- PostgreSQL/Supabase is the target canonical store for source metadata, memory entities, revisions, ingestion state, outbox events, and publication decisions.
-- The private memory repository is canonical for reviewed journal text, policy, corrections, and human-maintained memory views.
-- Graphiti, Cognee, pgvector, and Qdrant are rebuildable projections.
-- Publication is a separate explicit decision.
-- Target ingestion idempotency uses `source_hash + pipeline_version`.
-- Corrections append revisions rather than destroying prior values.
-- Directory scans and file existence are current legacy mechanisms, not the v2 state model.
+この処理は、証拠を削除、移動、upload、書換えしません。
 
-## Documentation
+production inventoryが未実行の状態では、移行対象の総量や重複解消を完了したと主張しません。
 
-Start with the [documentation index](docs/README.md).
+---
 
-- [Product overview and status](docs/overview.md)
-- [Human Memory v2 target architecture](docs/architecture/human-memory-v2.md)
-- [Current runtime architecture](docs/architecture.md)
-- [Phase 0 inventory runbook](docs/operations/phase0-inventory.md)
-- [Operations](docs/OPERATIONS.md)
-- [Maintenance](docs/MAINTENANCE.md)
-- [Current daily pipeline contract](docs/daily_pipeline_contract.md)
-- [Agent router](AGENTS.md)
+## canonical rule
 
-Production reader: [kaflog.vercel.app](https://kaflog.vercel.app)
+### Raw evidence
 
-## Documentation governance
+原音声、写真、動画などのbyte列は、private object storageを最終canonicalとします。
 
-All Markdown is governed by [docs/markdown-governance.md](docs/markdown-governance.md). Generic agent tutorials and point-in-time service status do not belong in the active documentation corpus.
+### Metadataとmemory state
+
+PostgreSQL / Supabaseを、次のtarget canonical storeとします。
+
+- source metadata
+- episode、moment、entity
+- memory claimとrevision
+- ingestion state
+- outbox event
+- publication decision
+
+### 人間が管理する記憶view
+
+private memory repositoryを、次のcanonicalとします。
+
+- review済みjournal text
+- policy
+- correction
+- 人間が維持するmemory view
+
+### 再構築可能なprojection
+
+Graphiti、Cognee、pgvector、Qdrantなどはprojectionです。canonical dataから再生成可能でなければなりません。
+
+### idempotency
+
+目標のingestion idempotency keyは、`source_hash + pipeline_version`です。
+
+---
+
+## readerと公開物
+
+readerの実装は`apps/reader/`にあります。
+
+READMEに記載されていた公開候補URL:
+
+- https://kaflog.vercel.app/
+
+この環境から2026年8月4日に外部応答を確認できなかったため、現在稼働中とは断定しません。Vercelのdeploy、実URL、表示内容、公開データを個別に確認してください。
+
+公開物は、明示的に公開承認されたprojectionだけを含むべきです。
+
+---
+
+## 検証
+
+### repository内で確認できること
+
+- Python test
+- schema validation
+- accepted claimのprovenance invariant
+- repository boundary
+- portable path
+- systemd template生成
+- Windows assetの構造
+- reader build
+- Markdown governance
+- retired documentの再混入防止
+
+### repository外で確認すること
+
+- 録音deviceとVRChat process
+- transcription modelのruntime
+- systemd enable・restart・failure recovery
+- Windows Task Scheduler
+- Supabase data、migration、RLS
+- private storageのmanifest
+- Vercel deploy
+- 公開・非公開境界の実運用
+
+検証できない項目は、READMEやCIの記述で代替しません。
+
+---
+
+## 文書
+
+最初に[`docs/README.md`](docs/README.md)を参照してください。
+
+- [`docs/overview.md`](docs/overview.md) — 製品概要と現在状態
+- [`docs/architecture/human-memory-v2.md`](docs/architecture/human-memory-v2.md) — target architecture
+- [`docs/architecture.md`](docs/architecture.md) — 現行runtime architecture
+- [`docs/operations/phase0-inventory.md`](docs/operations/phase0-inventory.md) — inventory runbook
+- [`docs/OPERATIONS.md`](docs/OPERATIONS.md) — 運用
+- [`docs/MAINTENANCE.md`](docs/MAINTENANCE.md) — 保守
+- [`docs/daily_pipeline_contract.md`](docs/daily_pipeline_contract.md) — 現行daily pipeline contract
+- [`docs/markdown-governance.md`](docs/markdown-governance.md) — Markdown governance
+- [`AGENTS.md`](AGENTS.md) — agent router
+
+genericなagent tutorialや、一時点のservice statusはactive documentationへ混ぜません。
+
+---
+
+## セキュリティとプライバシー
+
+公開リポジトリへ保存しないもの:
+
+- 原音声、写真、動画
+- 会話全文
+- private journal
+- 個人名、関係性、位置情報などの個人情報
+- API key、token、cookie、credential
+- private object storage URL
+- 未公開artifact
+- redaction前の運用log
+
+log、screenshot、Issue、PRへ証拠を添付する場合も、公開範囲とredactionを確認します。
+
+---
+
+## 既知の制約
+
+- Human Memory v2は移行中で、canonical PostgreSQL persistenceは未完成です。
+- private memory repositoryとprivate object storageの実移行は未完了です。
+- 現在も一部の処理状態はfile existenceに依存します。
+- graph・vector retrievalは最終構成ではありません。
+- systemd、Windows、Supabase、Vercelの実host cutoverは、repository CIだけでは確認できません。
+- AI生成の要約や日記は、人間の記憶や事実を自動確定しません。
+- 公開承認のない証拠をpublic projectionへ含めてはいけません。
+
+---
+
+## README.mdとAGENTS.md
+
+- `README.md`は、人間が目的、構造、現在状態、使い方、正準、制約を理解する入口です。
+- `AGENTS.md`は、AIエージェントを適切なproject-specific instructionへ案内するrouterです。
+
+重要な人間向け情報をAGENTS.mdだけへ置きません。
+
+---
+
+## ライセンス
+
+コードのlicenseはrepositoryの`LICENSE`を確認してください。原証拠、個人の記憶、生成artifact、外部model・serviceには、それぞれ別の権利と利用条件が適用されます。
+
+**README実体監査:** 2026年8月4日


### PR DESCRIPTION
## 関連

- KAFKA2306/com#3
- KAFKA2306/vlog#14

## 変更

- 英語READMEを日本語へ全面改稿
- Evidence、Human Memory、Narrative Artifact、Public Projectionの層を説明
- 現在の実装済み範囲と未完了のcanonical persistence・private storage・retrievalを明示
- 公開OSS、private memory、private object storage、public projectionの境界を説明
- setup、task、inventory、canonical rule、検証、security、制約を人間向けに整理
- `kaflog.vercel.app`は現在稼働を確認できていないため、公開候補URLとして明示

## 確認根拠

- 2026年8月4日のPR #15〜#18 merge commit
- 現在のREADME、docs index、Human Memory v2 issue
- repository boundaryとMarkdown governanceの実装状況

## 検証

README変更を対象にするCIと文書検証を確認し、成功後にmergeする。
