### PR TITLE
Test WSL drive-path guard without changing Windows behavior

### DIFF
--- a/apps/capture-vrchat/src/infrastructure/settings.py
+++ b/apps/capture-vrchat/src/infrastructure/settings.py
@@ -12,10 +12,15 @@ def _get_project_root() -> Path:
     return PROJECT_ROOT
 
 
+def is_windows_path_invalid_on_linux(
+    value: Path, *, system: str | None = None
+) -> bool:
+    runtime_system = system or platform.system()
+    return runtime_system == "Linux" and PureWindowsPath(str(value)).is_absolute()
+
+
 def resolve_project_path(value: Path) -> Path:
-    raw_value = str(value)
-    windows_path = PureWindowsPath(raw_value)
-    if platform.system() == "Linux" and windows_path.is_absolute():
+    if is_windows_path_invalid_on_linux(value):
         raise ValueError(f"Windows path is not valid in WSL: {value}")
     if value.is_absolute():
         return value

--- a/apps/capture-vrchat/src/infrastructure/settings.py
+++ b/apps/capture-vrchat/src/infrastructure/settings.py
@@ -12,9 +12,7 @@ def _get_project_root() -> Path:
     return PROJECT_ROOT
 
 
-def is_windows_path_invalid_on_linux(
-    value: Path, *, system: str | None = None
-) -> bool:
+def is_windows_path_invalid_on_linux(value: Path, *, system: str | None = None) -> bool:
     runtime_system = system or platform.system()
     return runtime_system == "Linux" and PureWindowsPath(str(value)).is_absolute()
 

--- a/tests/test_settings_paths.py
+++ b/tests/test_settings_paths.py
@@ -14,7 +14,12 @@ def test_resolve_project_path_anchors_relative_paths() -> None:
     )
 
 
-def test_resolve_project_path_rejects_windows_paths_in_wsl() -> None:
+def test_resolve_project_path_rejects_windows_drive_paths_in_wsl() -> None:
+    with pytest.raises(ValueError, match="Windows path is not valid in WSL"):
+        resolve_project_path(Path(r"Z:\home\kafka\projects\vlog\transcripts"))
+
+
+def test_resolve_project_path_rejects_windows_unc_paths_in_wsl() -> None:
     with pytest.raises(ValueError, match="Windows path is not valid in WSL"):
         resolve_project_path(Path(r"\\wsl.localhost\Ubuntu-22.04\home\kafka"))
 
@@ -23,5 +28,12 @@ def test_settings_rejects_windows_paths_in_wsl() -> None:
     with pytest.raises(ValueError, match="Windows path is not valid in WSL"):
         Settings(
             GOOGLE_API_KEY="test",
-            VLOG_RECORDING_DIR=r"\\wsl.localhost\Ubuntu-22.04\home\kafka",
+            VLOG_RECORDING_DIR=r"Z:\home\kafka\projects\vlog\recordings",
         )
+
+
+def test_windows_runtime_preserves_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.infrastructure.settings.platform.system", lambda: "Windows")
+    value = Path(r"Z:\home\kafka\projects\vlog\transcripts")
+
+    assert resolve_project_path(value) == value

--- a/tests/test_settings_paths.py
+++ b/tests/test_settings_paths.py
@@ -4,6 +4,7 @@ import pytest
 from src.infrastructure.settings import (
     Settings,
     _get_project_root,
+    is_windows_path_invalid_on_linux,
     resolve_project_path,
 )
 
@@ -32,8 +33,8 @@ def test_settings_rejects_windows_paths_in_wsl() -> None:
         )
 
 
-def test_windows_runtime_preserves_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("src.infrastructure.settings.platform.system", lambda: "Windows")
+def test_windows_drive_path_guard_is_linux_only() -> None:
     value = Path(r"Z:\home\kafka\projects\vlog\transcripts")
 
-    assert resolve_project_path(value) == value
+    assert is_windows_path_invalid_on_linux(value, system="Linux")
+    assert not is_windows_path_invalid_on_linux(value, system="Windows")


### PR DESCRIPTION
## Summary

- add regression coverage for the exact `Z:\\...` drive-path case reported in #5
- retain UNC-path coverage
- prove that the guard is Linux-only, so PowerShell 7 / native Windows paths remain unchanged

The production path resolver on `main` already rejects absolute Windows paths when `platform.system() == "Linux"`; this PR closes the missing audit gap for the original reproduction and the explicit Windows compatibility concern.

## Verification

- `tests/test_settings_paths.py` exercises relative paths, Windows drive paths under Linux/WSL, UNC paths under Linux/WSL, Settings validation, and native Windows preservation
- existing GitHub Actions test and lint workflows are expected to run on this PR

Closes #5