### PR TITLE
Fail closed when Windows UNC project paths are unavailable

### DIFF
--- a/infra/windows/bootstrap.bat
+++ b/infra/windows/bootstrap.bat
@@ -1,5 +1,18 @@
 @echo off
-pushd "%~dp0..\.."
+setlocal
+set "PROJECT_ROOT=%~dp0..\.."
+pushd "%PROJECT_ROOT%" 2>nul
+if errorlevel 1 (
+  echo ERROR: Could not open the project directory: "%PROJECT_ROOT%" 1>&2
+  echo If the repository is on a UNC or WSL share, map it to a Windows drive or copy it to a local Windows path, then run this script again. 1>&2
+  exit /b 1
+)
+
+if not exist "pyproject.toml" (
+  echo ERROR: The resolved project directory is invalid: "%CD%" 1>&2
+  popd
+  exit /b 1
+)
 
 set "UV_PROJECT_ENVIRONMENT=.venv-win"
 set "UV_LINK_MODE=copy"
@@ -15,18 +28,28 @@ if not exist ".env" (
   type nul > ".env"
 )
 
-
-
-
-
 if not exist "data\recordings" mkdir "data\recordings"
 if not exist "data\transcripts" mkdir "data\transcripts"
 if not exist "data\summaries" mkdir "data\summaries"
 if not exist "data\archives" mkdir "data\archives"
 if not exist "data\logs" mkdir "data\logs"
-uv sync --frozen || exit /b %ERRORLEVEL%
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0register_task.ps1" -RunScript "%~dp0run.bat" || exit /b %ERRORLEVEL%
+uv sync --frozen
+if errorlevel 1 (
+  set "EXIT_CODE=%ERRORLEVEL%"
+  popd
+  exit /b %EXIT_CODE%
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0register_task.ps1" -RunScript "%~dp0run.bat"
+if errorlevel 1 (
+  set "EXIT_CODE=%ERRORLEVEL%"
+  popd
+  exit /b %EXIT_CODE%
+)
 
 echo Bootstrap complete. Task scheduled.
 schtasks /Run /TN "VlogAutoDiary"
+set "EXIT_CODE=%ERRORLEVEL%"
+popd
 pause
+exit /b %EXIT_CODE%

--- a/infra/windows/bootstrap.bat
+++ b/infra/windows/bootstrap.bat
@@ -34,22 +34,18 @@ if not exist "data\summaries" mkdir "data\summaries"
 if not exist "data\archives" mkdir "data\archives"
 if not exist "data\logs" mkdir "data\logs"
 uv sync --frozen
-if errorlevel 1 (
-  set "EXIT_CODE=%ERRORLEVEL%"
-  popd
-  exit /b %EXIT_CODE%
-)
+if errorlevel 1 goto :failed
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0register_task.ps1" -RunScript "%~dp0run.bat"
-if errorlevel 1 (
-  set "EXIT_CODE=%ERRORLEVEL%"
-  popd
-  exit /b %EXIT_CODE%
-)
+if errorlevel 1 goto :failed
 
 echo Bootstrap complete. Task scheduled.
 schtasks /Run /TN "VlogAutoDiary"
-set "EXIT_CODE=%ERRORLEVEL%"
+if errorlevel 1 goto :failed
 popd
 pause
-exit /b %EXIT_CODE%
+exit /b 0
+
+:failed
+popd
+exit /b 1

--- a/infra/windows/run.bat
+++ b/infra/windows/run.bat
@@ -1,6 +1,18 @@
 @echo off
+setlocal
 set "PROJECT_ROOT=%~dp0..\.."
-pushd "%PROJECT_ROOT%"
+pushd "%PROJECT_ROOT%" 2>nul
+if errorlevel 1 (
+  echo ERROR: Could not open the project directory: "%PROJECT_ROOT%" 1>&2
+  echo If the repository is on a UNC or WSL share, map it to a Windows drive or copy it to a local Windows path, then run this script again. 1>&2
+  exit /b 1
+)
+
+if not exist "pyproject.toml" (
+  echo ERROR: The resolved project directory is invalid: "%CD%" 1>&2
+  popd
+  exit /b 1
+)
 
 set "UV_PROJECT_ENVIRONMENT=.venv-win"
 set "UV_LINK_MODE=copy"

--- a/tests/test_windows_bootstrap.py
+++ b/tests/test_windows_bootstrap.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_DIR = ROOT / "infra" / "windows"
+
+
+def _read(name: str) -> str:
+    return (WINDOWS_DIR / name).read_text(encoding="utf-8")
+
+
+def test_windows_launchers_fail_closed_when_project_directory_is_unavailable() -> None:
+    for name in ("run.bat", "bootstrap.bat"):
+        script = _read(name)
+        assert 'pushd "%PROJECT_ROOT%" 2>nul' in script
+        assert "if errorlevel 1 (" in script
+        assert "Could not open the project directory" in script
+        assert "UNC or WSL share" in script
+        assert 'if not exist "pyproject.toml" (' in script
+        assert "exit /b 1" in script
+
+
+def test_windows_launchers_restore_directory_after_success() -> None:
+    run_script = _read("run.bat")
+    bootstrap_script = _read("bootstrap.bat")
+
+    assert "popd\nexit /b %EXIT_CODE%" in run_script
+    assert ":failed\npopd\nexit /b 1" in bootstrap_script
+    assert "popd\npause\nexit /b 0" in bootstrap_script
+
+
+def test_windows_guide_explains_unc_mapping_and_failure_mode() -> None:
+    guide = _read("README.md")
+    assert "UNC" in guide
+    assert "pushd" in guide
+    assert "一時ドライブ" in guide


### PR DESCRIPTION
## Summary

- stop `infra/windows/run.bat` and `bootstrap.bat` immediately when `pushd` cannot enter the project directory
- verify that the resolved directory contains `pyproject.toml` before creating files, syncing dependencies, or launching the app
- preserve directory cleanup and non-zero exit status on bootstrap failures
- add regression tests for the UNC/WSL failure guard and cleanup paths

## Root cause

The launchers called `pushd` but did not inspect its exit status. When a UNC or WSL share was unavailable, subsequent relative-path operations could continue from an unrelated current directory.

Microsoft documents that, with command extensions enabled, `pushd` accepts network paths and temporarily assigns an unused drive letter. The implementation now relies on that behavior when available and fails closed when it is not: https://learn.microsoft.com/windows-server/administration/windows-commands/pushd

## Validation

- static regression coverage in `tests/test_windows_bootstrap.py`
- existing repository CI is expected to run the complete pytest, boundary-audit, lint, format, systemd, and reader checks

Closes #3