### PR TITLE
Fix Ruff formatting for UNC regression test

### DIFF
--- a/tests/test_windows_bootstrap.py
+++ b/tests/test_windows_bootstrap.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 WINDOWS_DIR = ROOT / "infra" / "windows"
 


### PR DESCRIPTION
## Summary

- remove the extra blank line in `tests/test_windows_bootstrap.py`
- satisfy Ruff `I001` so the full Python test workflow can proceed past lint

## Evidence

Main workflow run #31218529981 completed Python compile successfully but stopped at `Lint Python sources` with Ruff `I001` on line 1 of this file. The reader job passed.

## Validation

This is the exact one-line formatting correction suggested by Ruff. After merge, the main workflows will be checked again before Issue #3 is closed.

Refs #3