### PR TITLE
Improve Windows launcher observability

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -39,9 +39,9 @@ tasks:
           task photos:all               全小説から画像を一括生成
 
         ■ Windows 起動
-          ダブルクリック: infra\windows\run.bat
+          ダブルクリック: run.bat
         ■ 初回セットアップ（管理者権限で実行）
-          infra\windows\bootstrap.bat
+          bootstrap.bat
 
         ■ データ同期
           task sync                     Supabase同期

--- a/apps/capture-vrchat/src/app.py
+++ b/apps/capture-vrchat/src/app.py
@@ -27,6 +27,7 @@ from src.use_cases.process_recording import ProcessRecordingUseCase
 
 logger = logging.getLogger(__name__)
 _AUDIO_RESOURCE = "audio-input:default"
+_HEARTBEAT_LOG_INTERVAL_SECONDS = 300
 
 
 class Application:
@@ -47,6 +48,8 @@ class Application:
         self._processing_threads: set[threading.Thread] = set()
         self._next_recording_retry_at = 0.0
         self._last_heartbeat_at = 0.0
+        self._last_heartbeat_log_at = 0.0
+        self._last_heartbeat_log_state: tuple[str, bool | None] | None = None
 
     def run(self) -> None:
         logger.info("Application started")
@@ -471,6 +474,34 @@ class Application:
             status=status,
             context=context,
         )
+        heartbeat_state = (status, vrchat_running)
+        state_changed = heartbeat_state != self._last_heartbeat_log_state
+        if (
+            state_changed
+            or now - self._last_heartbeat_log_at >= _HEARTBEAT_LOG_INTERVAL_SECONDS
+        ):
+            self._last_heartbeat_log_at = now
+            self._last_heartbeat_log_state = heartbeat_state
+            if status == "degraded":
+                logger.warning(
+                    "Monitor heartbeat: VRChat process detection is degraded; "
+                    "recording=%s; workers=%s",
+                    context["recording"],
+                    context["processing_threads"],
+                )
+            elif vrchat_running:
+                logger.info(
+                    "Monitor heartbeat: VRChat detected; recording=%s; workers=%s",
+                    context["recording"],
+                    context["processing_threads"],
+                )
+            else:
+                logger.info(
+                    "Monitor waiting: VRChat process not detected; "
+                    "recording=%s; workers=%s",
+                    context["recording"],
+                    context["processing_threads"],
+                )
         systemd_notify(
             "WATCHDOG=1",
             f"STATUS=VLog {status}; recording={context['recording']}; workers={context['processing_threads']}",

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,0 +1,3 @@
+@echo off
+call "%~dp0infra\windows\bootstrap.bat" %*
+exit /b %ERRORLEVEL%

--- a/infra/windows/README.md
+++ b/infra/windows/README.md
@@ -6,7 +6,9 @@ Windows は VRChat プロセスの検知と録音を担当し、WSL は日次処
 
 管理者権限のコマンドプロンプトでプロジェクトルートから実行する。
 
-    infra/windows/bootstrap.bat
+    bootstrap.bat
+
+リポジトリ直下の `bootstrap.bat` は、Windows 用実体を呼び出すランチャーである。
 
 bootstrap.bat は次を実行する。
 
@@ -21,7 +23,9 @@ bootstrap.bat は次を実行する。
 
 ## 手動起動
 
-    infra/windows/run.bat
+    run.bat
+
+リポジトリ直下の `run.bat` は、Windows 用実体を呼び出すランチャーである。
 
 run.bat は UNC パスを一時ドライブへ割り当て、.venv-win と Python 3.12 と `apps/capture-vrchat` を含む `PYTHONPATH` で `src.main` を実行する。相対パスは必ずプロジェクトルート基準で解決される。依存関係は uv.lock から変更しない。
 
@@ -49,6 +53,8 @@ WSL 側から全体状態を確認する。
     Get-Content data/logs/vlog.log -Tail 50
 
 windows-bootstrap.log は起動ごとに初期化され、起動時刻、解決済みパス、作業ディレクトリ、異常終了時の終了コードを記録する。
+
+`vlog.log` は起動時に加えて、VRChat が待機中・検出中であることを状態変更時に記録し、同じ状態が続く場合は 5 分ごとに heartbeat を記録する。30 秒ごとの内部 heartbeat は `data/heartbeats/vlog-service.json` を更新する。
 
 ## 停止と再起動
 

--- a/infra/windows/register_task.ps1
+++ b/infra/windows/register_task.ps1
@@ -3,7 +3,8 @@ param(
     [string]$RunScript
 )
 
-$runScript = (Resolve-Path -LiteralPath $RunScript).Path
+$ErrorActionPreference = "Stop"
+$runScript = (Resolve-Path -LiteralPath $RunScript).ProviderPath
 $arguments = '/d /c call ""{0}""' -f $runScript
 $action = New-ScheduledTaskAction -Execute $env:ComSpec -Argument $arguments
 $trigger = New-ScheduledTaskTrigger -AtLogOn

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,3 @@
+@echo off
+call "%~dp0infra\windows\run.bat" %*
+exit /b %ERRORLEVEL%

--- a/tests/test_app_heartbeat.py
+++ b/tests/test_app_heartbeat.py
@@ -1,0 +1,56 @@
+import logging
+from unittest.mock import Mock
+
+from src.app import Application
+
+
+def _heartbeat_app() -> Application:
+    app = Application.__new__(Application)
+    app._last_heartbeat_at = -30.0
+    app._last_heartbeat_log_at = -300.0
+    app._last_heartbeat_log_state = None
+    app._events = Mock()
+    app._recorder = Mock()
+    app._recorder.is_recording = False
+    app._active_file = None
+    app._processing_threads = set()
+    return app
+
+
+def test_waiting_heartbeat_is_logged_immediately_and_periodically(
+    monkeypatch, caplog
+) -> None:
+    app = _heartbeat_app()
+    current_time = 1.0
+    monkeypatch.setattr("src.app.time.monotonic", lambda: current_time)
+
+    with caplog.at_level(logging.INFO, logger="src.app"):
+        app._heartbeat("healthy", vrchat_running=False)
+        current_time = 20.0
+        app._heartbeat("healthy", vrchat_running=False)
+        current_time = 331.0
+        app._heartbeat("healthy", vrchat_running=False)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Monitor waiting: VRChat process not detected; recording=False; workers=0",
+        "Monitor waiting: VRChat process not detected; recording=False; workers=0",
+    ]
+
+
+def test_heartbeat_logs_immediately_when_vrchat_state_changes(
+    monkeypatch, caplog
+) -> None:
+    app = _heartbeat_app()
+    current_time = 1.0
+    monkeypatch.setattr("src.app.time.monotonic", lambda: current_time)
+
+    with caplog.at_level(logging.INFO, logger="src.app"):
+        app._heartbeat("healthy", vrchat_running=False)
+        current_time = 31.0
+        app._heartbeat("healthy", vrchat_running=True)
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "Monitor waiting: VRChat process not detected; recording=False; workers=0",
+        "Monitor heartbeat: VRChat detected; recording=False; workers=0",
+    ]

--- a/tests/test_windows_bootstrap.py
+++ b/tests/test_windows_bootstrap.py
@@ -8,6 +8,15 @@ def _read(name: str) -> str:
     return (WINDOWS_DIR / name).read_text(encoding="utf-8")
 
 
+def test_root_launchers_delegate_to_windows_implementation() -> None:
+    assert (ROOT / "run.bat").read_text(encoding="utf-8") == (
+        '@echo off\ncall "%~dp0infra\\windows\\run.bat" %*\nexit /b %ERRORLEVEL%\n'
+    )
+    assert (ROOT / "bootstrap.bat").read_text(encoding="utf-8") == (
+        '@echo off\ncall "%~dp0infra\\windows\\bootstrap.bat" %*\nexit /b %ERRORLEVEL%\n'
+    )
+
+
 def test_windows_launchers_fail_closed_when_project_directory_is_unavailable() -> None:
     for name in ("run.bat", "bootstrap.bat"):
         script = _read(name)
@@ -33,3 +42,9 @@ def test_windows_guide_explains_unc_mapping_and_failure_mode() -> None:
     assert "UNC" in guide
     assert "pushd" in guide
     assert "一時ドライブ" in guide
+
+
+def test_task_registration_uses_a_windows_filesystem_path_and_stops_on_errors() -> None:
+    script = (WINDOWS_DIR / "register_task.ps1").read_text(encoding="utf-8")
+    assert '$ErrorActionPreference = "Stop"' in script
+    assert "Resolve-Path -LiteralPath $RunScript).ProviderPath" in script


### PR DESCRIPTION
## Summary

- add root-level Windows launcher entry points
- log monitor heartbeat on state changes and every five minutes
- fix scheduled-task UNC path registration and fail on registration errors

## Validation

- `PYTHONPATH=apps/capture-vrchat pytest -q tests/test_app_heartbeat.py tests/test_windows_bootstrap.py`
- `ruff check apps/capture-vrchat/src/app.py tests/test_app_heartbeat.py tests/test_windows_bootstrap.py`
- verified Windows `run.bat` emitted a live heartbeat in `data/logs/vlog.log`