### PR TITLE
Integrate local-learning VRChat companion projection

### DIFF
--- a/.github/workflows/companion-pages.yml
+++ b/.github/workflows/companion-pages.yml
@@ -1,0 +1,110 @@
+name: Companion Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/companion-lab/**"
+      - ".github/workflows/companion-pages.yml"
+  pull_request:
+    paths:
+      - "apps/companion-lab/**"
+      - ".github/workflows/companion-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: vlog-companion-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      pages_enabled: ${{ steps.pages.outputs.enabled }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate static companion lab
+        run: |
+          set -euo pipefail
+          test -s apps/companion-lab/index.html
+          test -s apps/companion-lab/app.js
+          node --check apps/companion-lab/app.js
+          grep -F 'vlog-companion-lab-v1' apps/companion-lab/index.html
+          grep -F '73 bit' apps/companion-lab/index.html
+
+      - name: Assemble Pages artifact
+        run: |
+          rm -rf _site
+          mkdir _site
+          cp -R apps/companion-lab/. _site/
+          touch _site/.nojekyll
+
+      - name: Detect GitHub Pages configuration
+        id: pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          status="$(curl --silent --show-error -o pages-config.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")"
+          if [ "$status" = "200" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "404" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "### GitHub Pages is not enabled yet" >> "$GITHUB_STEP_SUMMARY"
+            echo "Enable Settings → Pages → Source: GitHub Actions once, then rerun this workflow." >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat pages-config.json
+            exit 1
+          fi
+
+      - name: Configure Pages
+        if: github.event_name != 'pull_request' && steps.pages.outputs.enabled == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request' && steps.pages.outputs.enabled == 'true'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+  deploy:
+    if: github.event_name != 'pull_request' && needs.build.outputs.pages_enabled == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Verify public companion lab
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          matched=false
+          for attempt in $(seq 1 24); do
+            curl --fail --silent --show-error --location "${PAGE_URL}?smoke=${EXPECTED_SHA}-${attempt}" -o "$tmp/index.html"
+            if grep -Fq 'vlog-companion-lab-v1' "$tmp/index.html"; then
+              matched=true
+              break
+            fi
+            sleep 10
+          done
+          test "$matched" = true
+          curl --fail --silent --show-error --location "${PAGE_URL}app.js?smoke=${EXPECTED_SHA}" -o "$tmp/app.js"
+          grep -F 'vlog.companion.demo.words.v1' "$tmp/app.js"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOOGLE_API_KEY: test-key
-      PYTHONPATH: apps/capture-vrchat:packages/memory-domain/src:packages/ingestion/src
+      PYTHONPATH: apps/capture-vrchat:packages/memory-domain/src:packages/ingestion/src:packages/companion/src:adapters/vrchat-osc/src
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -31,9 +31,9 @@ jobs:
           soundfile
           google-generativeai
       - name: Compile Python sources
-        run: uv run --no-sync python -m compileall -q apps/capture-vrchat/src packages scripts tests infra/systemd
+        run: uv run --no-sync python -m compileall -q apps/capture-vrchat/src packages adapters scripts tests infra/systemd
       - name: Lint Python sources
-        run: uvx ruff check apps/capture-vrchat/src packages scripts tests infra/systemd
+        run: uvx ruff check apps/capture-vrchat/src packages adapters scripts tests infra/systemd
       - name: Enforce public/private repository boundaries
         run: uv run --no-sync python scripts/check_repository_boundaries.py
       - name: Verify rendered systemd units

--- a/adapters/vrchat-osc/README.md
+++ b/adapters/vrchat-osc/README.md
@@ -1,0 +1,13 @@
+# VRChat OSC adapter
+
+Replaceable UDP OSC output for companion projections.
+
+Default target: `127.0.0.1:9000`.
+
+Parameters emitted by `VrchatOsc.speak`:
+
+- `PetChar0` ... `PetChar7`: integer character IDs
+- `PetMood`: integer 0-255
+- `PetSpeak`: boolean pulse
+
+This adapter does not persist evidence or memory. VRChat client reception, Animator behavior, and avatar parameter wiring require separate runtime verification.

--- a/adapters/vrchat-osc/src/vlog_vrchat_osc/__init__.py
+++ b/adapters/vrchat-osc/src/vlog_vrchat_osc/__init__.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import socket
+import struct
+import time
+
+
+def _osc_string(value: str) -> bytes:
+    data = value.encode("utf-8") + b"\0"
+    return data + b"\0" * ((4 - len(data) % 4) % 4)
+
+
+def osc_message(address: str, value: int | bool) -> bytes:
+    if isinstance(value, bool):
+        return _osc_string(address) + _osc_string(",T" if value else ",F")
+    return _osc_string(address) + _osc_string(",i") + struct.pack(">i", int(value))
+
+
+class VrchatOsc:
+    def __init__(self, host: str = "127.0.0.1", port: int = 9000) -> None:
+        self.target = (host, port)
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def send_int(self, name: str, value: int) -> None:
+        self.socket.sendto(osc_message(f"/avatar/parameters/{name}", value), self.target)
+
+    def send_bool(self, name: str, value: bool) -> None:
+        self.socket.sendto(osc_message(f"/avatar/parameters/{name}", value), self.target)
+
+    def speak(self, chars: list[int], mood: int = 0, pulse_seconds: float = 0.18) -> None:
+        for index, value in enumerate(chars):
+            self.send_int(f"PetChar{index}", value)
+        self.send_int("PetMood", max(0, min(255, mood)))
+        self.send_bool("PetSpeak", True)
+        time.sleep(pulse_seconds)
+        self.send_bool("PetSpeak", False)

--- a/apps/companion-lab/README.md
+++ b/apps/companion-lab/README.md
@@ -1,0 +1,20 @@
+# Companion Lab
+
+Static public projection for GitHub Pages.
+
+This UI demonstrates only:
+
+- term observation counts;
+- frequency/recency weighted sampling;
+- kana-to-integer quantization;
+- the 73-bit VRChat parameter shape.
+
+It deliberately does not load VLog private evidence, transcripts, journals, people data, or credentials. Browser demo state stays in `localStorage` under `vlog.companion.demo.words.v1`.
+
+Canonical implementation boundaries:
+
+- domain math: `packages/companion/`
+- VRChat UDP OSC: `adapters/vrchat-osc/`
+- static view: `apps/companion-lab/`
+
+GitHub Pages deployment is handled by `.github/workflows/companion-pages.yml`. Repository Pages must be enabled once with **Settings → Pages → Source: GitHub Actions** before deployment can occur.

--- a/apps/companion-lab/app.js
+++ b/apps/companion-lab/app.js
@@ -1,0 +1,94 @@
+const STORAGE_KEY = 'vlog.companion.demo.words.v1';
+const KANA = 'アイウエオカキクケコガギグゲゴサシスセソザジズゼゾタチツテトダヂヅデドナニヌネノハヒフヘホバビブベボパピプペポマミムメモヤユヨラリルレロワヲンァィゥェォャュョッーヴ';
+const kanaToInt = new Map([...KANA].map((char, index) => [char, index + 1]));
+
+const $ = (selector) => document.querySelector(selector);
+const wordsEl = $('#words');
+const speechEl = $('#speech');
+const paramsEl = $('#params');
+const readingEl = $('#reading');
+let words = load();
+
+function load() {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}; }
+  catch { return {}; }
+}
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(words)); }
+function katakana(text) {
+  return [...text].map((char) => {
+    const code = char.codePointAt(0);
+    return code >= 0x3041 && code <= 0x3096 ? String.fromCodePoint(code + 0x60) : char;
+  }).join('');
+}
+function encodeReading(reading) {
+  const values = [...katakana(reading)].slice(0, 8).map((char) => kanaToInt.get(char) || 0);
+  while (values.length < 8) values.push(0);
+  return values;
+}
+function parseEntries(text) {
+  return text.split(/[\s、，,]+/u).map((value) => value.trim()).filter(Boolean).map((raw) => {
+    const slash = raw.indexOf('/');
+    if (slash < 0) return { text: raw, reading: raw };
+    return { text: raw.slice(0, slash), reading: raw.slice(slash + 1) || raw.slice(0, slash) };
+  }).filter((entry) => entry.text && entry.reading);
+}
+function observe(entries) {
+  const now = Date.now() / 1000;
+  for (const entry of entries) {
+    const current = words[entry.text];
+    words[entry.text] = { text: entry.text, reading: entry.reading, count: (current?.count || 0) + 1, lastSeen: now };
+  }
+  save(); renderWords();
+}
+function weight(word, now = Date.now() / 1000) {
+  const ageDays = Math.max(0, now - word.lastSeen) / 86400;
+  return Math.pow(word.count + 0.5, 0.8) * Math.exp(-0.035 * ageDays);
+}
+function choose() {
+  const list = Object.values(words);
+  if (!list.length) return null;
+  const weights = list.map((word) => weight(word));
+  const total = weights.reduce((a, b) => a + b, 0);
+  let cursor = Math.random() * total;
+  for (let index = 0; index < list.length; index += 1) {
+    cursor -= weights[index];
+    if (cursor <= 0) return list[index];
+  }
+  return list.at(-1);
+}
+function escapeHtml(value) {
+  return value.replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]));
+}
+function renderWords() {
+  const list = Object.values(words).sort((a, b) => b.count - a.count || a.text.localeCompare(b.text, 'ja'));
+  if (!list.length) { wordsEl.innerHTML = '<p class="muted">まだ語を観測していません。</p>'; return; }
+  const max = Math.max(...list.map((word) => word.count));
+  wordsEl.innerHTML = list.map((word) => `<div class="word"><div><strong>${escapeHtml(word.text)}</strong><div class="muted">${escapeHtml(word.reading)}</div><div class="bar"><i style="width:${Math.max(5, word.count / max * 100)}%"></i></div></div><span class="muted">count</span><span>${word.count}</span></div>`).join('');
+}
+function renderParams(values = Array(8).fill(0), mood = 0, speak = false) {
+  const entries = values.map((value, index) => [`PetChar${index}`, value]);
+  entries.push(['PetMood', mood], ['PetSpeak', speak ? 1 : 0]);
+  paramsEl.innerHTML = entries.map(([name, value]) => `<div class="param"><span class="muted">${name}</span><b>${value}</b></div>`).join('');
+}
+function react() {
+  const word = choose();
+  if (!word) { speechEl.textContent = 'まだ記憶がない'; return; }
+  const values = encodeReading(word.reading);
+  speechEl.textContent = word.text;
+  renderParams(values, 0, true);
+  readingEl.textContent = `読み: ${katakana(word.reading)} / [${values.join(', ')}] → PetSpeak=true → 180ms後にfalse`;
+  window.setTimeout(() => renderParams(values, 0, false), 180);
+}
+
+$('#learn-form').addEventListener('submit', (event) => {
+  event.preventDefault();
+  const input = $('#learn-input');
+  const entries = parseEntries(input.value);
+  if (!entries.length) return;
+  observe(entries); input.value = ''; input.focus();
+});
+$('#seed').addEventListener('click', () => observe(parseEntries('猫/ネコ ラーメン VRChat/ブイアールチャット 猫/ネコ 猫/ネコ 音楽/オンガク')));
+$('#clear').addEventListener('click', () => { words = {}; save(); speechEl.textContent = '…'; readingEl.textContent = '反応を抽選すると、読みとAvatar Parameter値を表示します。'; renderWords(); renderParams(); });
+$('#speak').addEventListener('click', react);
+
+renderWords(); renderParams();

--- a/apps/companion-lab/index.html
+++ b/apps/companion-lab/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#f4f0e8">
+  <meta name="app-build" content="vlog-companion-lab-v1">
+  <meta name="description" content="VLogのローカル学習型VRChat companion projectionをブラウザで試す公開デモ。">
+  <title>VLog Companion Lab</title>
+  <style>
+    :root{--bg:#f4f0e8;--card:#fffdf8;--ink:#181713;--muted:#6f6b62;--line:#d9d2c4;--soft:#ebe4d7;--radius:20px}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,"Noto Sans JP",system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.65}.shell{width:min(1120px,calc(100% - 32px));margin:auto}a{color:inherit}.top{display:flex;justify-content:space-between;align-items:center;padding:24px 0}.brand{text-decoration:none;font-weight:900}.nav{display:flex;gap:10px}.btn,button{border:1px solid var(--ink);background:transparent;color:var(--ink);border-radius:999px;padding:10px 16px;font:inherit;font-weight:750;cursor:pointer;text-decoration:none}.btn.primary,button.primary{background:var(--ink);color:#fff}.hero{padding:68px 0 34px}.eyebrow{font-size:.78rem;letter-spacing:.13em;text-transform:uppercase;font-weight:850;color:var(--muted)}h1{font-size:clamp(2.8rem,8vw,6.7rem);line-height:.92;letter-spacing:-.06em;margin:.15em 0}.lead{max-width:780px;color:var(--muted);font-size:1.16rem}.status{display:inline-flex;gap:8px;align-items:center;margin-top:18px;padding:7px 12px;background:var(--soft);border-radius:999px;font-size:.86rem}.dot{width:8px;height:8px;border-radius:50%;background:#2f6846}.grid{display:grid;grid-template-columns:1.2fr .8fr;gap:18px;padding:24px 0 64px}.card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:24px;box-shadow:0 8px 28px rgba(38,32,20,.04)}.card h2{margin-top:0;font-size:1.35rem}.inputrow{display:flex;gap:10px}.inputrow input{flex:1;min-width:0;padding:13px 15px;border:1px solid var(--line);border-radius:12px;background:#fff;font:inherit}.muted,.hint{color:var(--muted);font-size:.9rem}.words{display:grid;gap:8px;margin-top:18px}.word{display:grid;grid-template-columns:1fr auto auto;gap:12px;align-items:center;padding:11px 12px;background:var(--bg);border-radius:12px}.bar{height:5px;background:#dcd5c8;border-radius:999px;overflow:hidden;margin-top:6px}.bar i{display:block;height:100%;background:var(--ink)}.speakbox{display:flex;align-items:center;justify-content:center;min-height:160px;border:1px dashed var(--line);border-radius:16px;background:var(--bg);font-size:clamp(2rem,6vw,4rem);font-weight:900;letter-spacing:-.04em;text-align:center;padding:20px}.formula{font-family:"SFMono-Regular",Consolas,monospace;background:var(--ink);color:#fff;padding:16px;border-radius:14px;overflow:auto}.params{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:14px}.param{padding:10px;background:var(--bg);border-radius:11px;text-align:center}.param b{display:block;font-size:1.15rem;font-variant-numeric:tabular-nums}.actions{display:flex;gap:9px;flex-wrap:wrap;margin:14px 0}.split{display:grid;grid-template-columns:1fr 1fr;gap:12px}.metric{padding:15px;background:var(--bg);border-radius:14px}.metric b{display:block;font-size:1.8rem}.notice{border-left:3px solid var(--ink);padding:3px 0 3px 14px;color:var(--muted)}footer{padding:0 0 38px;color:var(--muted);font-size:.9rem}@media(max-width:780px){.grid{grid-template-columns:1fr}.inputrow{flex-direction:column}.params{grid-template-columns:repeat(3,1fr)}.split{grid-template-columns:1fr}.hero{padding-top:38px}}
+  </style>
+</head>
+<body>
+<div class="shell">
+  <header class="top"><a class="brand" href="https://github.com/KAFKA2306/vlog">VLog / Companion Lab</a><nav class="nav"><a class="btn" href="https://github.com/KAFKA2306/vlog/tree/main/packages/companion">Source</a></nav></header>
+  <main>
+    <section class="hero">
+      <p class="eyebrow">Human Memory Engine / Companion projection</p>
+      <h1>記憶から、<br>反応が育つ。</h1>
+      <p class="lead">VLogが扱う会話・記憶そのものを公開せず、選択された語の頻度と鮮度だけから「その環境らしい」反応を作る、LLM不要のVRChat companion projectionです。</p>
+      <div class="status"><span class="dot"></span>公開デモはlocalStorageのみ。原音声・全文会話・個人情報は扱いません。</div>
+    </section>
+    <section class="grid">
+      <article class="card">
+        <h2>1. 語を観測する</h2>
+        <p class="hint">`語/ヨミ` を空白・読点・カンマで区切って入力します。例: <code>猫/ネコ ラーメン VRChat/ブイアールチャット 猫/ネコ</code></p>
+        <form id="learn-form" class="inputrow"><input id="learn-input" autocomplete="off" placeholder="猫/ネコ ラーメン 音楽/オンガク"><button class="primary" type="submit">観測</button></form>
+        <div class="actions"><button id="seed" type="button">サンプル投入</button><button id="clear" type="button">デモ記憶を消す</button></div>
+        <div id="words" class="words" aria-live="polite"></div>
+      </article>
+      <article class="card">
+        <h2>2. 確率で反応する</h2>
+        <div id="speech" class="speakbox">…</div>
+        <div class="actions"><button id="speak" class="primary" type="button">反応を抽選</button></div>
+        <div class="formula">wᵢ = (countᵢ + 0.5)^0.8 × exp(-0.035 × ageDaysᵢ)</div>
+        <p class="muted">頻繁に観測された語を好みつつ、古い語は少しずつ弱くなります。意味理解はしません。</p>
+      </article>
+      <article class="card">
+        <h2>3. VRChat用73bitへ量子化</h2>
+        <div class="split"><div class="metric"><span class="muted">同期量</span><b>73 bit</b><span class="muted">8×Int + Mood + Speak</span></div><div class="metric"><span class="muted">文字枠</span><b>8</b><span class="muted">カナ→整数ID</span></div></div>
+        <div id="params" class="params"></div>
+        <p id="reading" class="notice">反応を抽選すると、読みとAvatar Parameter値を表示します。</p>
+      </article>
+      <article class="card">
+        <h2>4. VLogとの境界</h2>
+        <p><strong>Evidence:</strong> 原音声・全文会話はprivate側。</p>
+        <p><strong>Human Memory:</strong> claim/revisionはVLogの正準ルールに従う。</p>
+        <p><strong>Companion:</strong> 選択済み語から作る再構築可能なprojection。記憶の事実認定には使わない。</p>
+        <p><strong>VRChat:</strong> OSC adapterが <code>127.0.0.1:9000</code> へ送信。実クライアント受信とAnimator表示は別の実機検証。</p>
+        <p class="notice">このgithub.ioデモはUDP OSCを送信しません。ブラウザ表示とVRChat実機証拠を混同しません。</p>
+      </article>
+    </section>
+  </main>
+  <footer>VLog Human Memory Engine — companion projection demo</footer>
+</div>
+<script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/packages/companion/README.md
+++ b/packages/companion/README.md
@@ -1,0 +1,22 @@
+# Companion projection
+
+`vlog_companion` is a storage-agnostic projection for a deliberately simple VRChat companion.
+
+It does not create or accept human memory claims. It consumes already-selected terms and produces ephemeral companion state:
+
+```text
+observed term + reading
+  -> count + last_seen
+  -> weighted sampling
+  -> 8 kana parameter slots
+```
+
+Sampling weight:
+
+```text
+w_i = (count_i + 0.5)^0.8 * exp(-0.035 * age_days_i)
+```
+
+The default VRChat parameter shape is eight 8-bit character slots, one 8-bit mood value, and one boolean speak pulse: 73 synced bits in total.
+
+This package contains no persistence, transcription, publication decision, or network I/O. Raw transcripts and private memory remain outside the public companion projection according to the repository privacy boundaries.

--- a/packages/companion/src/vlog_companion/__init__.py
+++ b/packages/companion/src/vlog_companion/__init__.py
@@ -1,0 +1,11 @@
+from .core import TermMemory, choose, encode_reading, katakana, observe, synced_parameter_bits, weight
+
+__all__ = [
+    "TermMemory",
+    "choose",
+    "encode_reading",
+    "katakana",
+    "observe",
+    "synced_parameter_bits",
+    "weight",
+]

--- a/packages/companion/src/vlog_companion/__init__.py
+++ b/packages/companion/src/vlog_companion/__init__.py
@@ -1,4 +1,12 @@
-from .core import TermMemory, choose, encode_reading, katakana, observe, synced_parameter_bits, weight
+from .core import (
+    TermMemory,
+    choose,
+    encode_reading,
+    katakana,
+    observe,
+    synced_parameter_bits,
+    weight,
+)
 
 __all__ = [
     "TermMemory",

--- a/packages/companion/src/vlog_companion/core.py
+++ b/packages/companion/src/vlog_companion/core.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import math
 import random
+from dataclasses import dataclass
 
 KANA = "アイウエオカキクケコガギグゲゴサシスセソザジズゼゾタチツテトダヂヅデドナニヌネノハヒフヘホバビブベボパピプペポマミムメモヤユヨラリルレロワヲンァィゥェォャュョッーヴ"
 KANA_TO_INT = {char: index + 1 for index, char in enumerate(KANA)}

--- a/packages/companion/src/vlog_companion/core.py
+++ b/packages/companion/src/vlog_companion/core.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import random
+
+KANA = "アイウエオカキクケコガギグゲゴサシスセソザジズゼゾタチツテトダヂヅデドナニヌネノハヒフヘホバビブベボパピプペポマミムメモヤユヨラリルレロワヲンァィゥェォャュョッーヴ"
+KANA_TO_INT = {char: index + 1 for index, char in enumerate(KANA)}
+
+
+@dataclass(frozen=True)
+class TermMemory:
+    text: str
+    reading: str
+    count: int
+    last_seen: float
+
+
+def observe(
+    state: dict[str, TermMemory],
+    text: str,
+    reading: str,
+    now: float,
+) -> TermMemory:
+    current = state.get(text)
+    memory = TermMemory(
+        text=text,
+        reading=reading,
+        count=(current.count if current else 0) + 1,
+        last_seen=now,
+    )
+    state[text] = memory
+    return memory
+
+
+def weight(
+    memory: TermMemory,
+    now: float,
+    alpha: float = 0.5,
+    beta: float = 0.8,
+    decay_per_day: float = 0.035,
+) -> float:
+    age_days = max(0.0, now - memory.last_seen) / 86400.0
+    return (memory.count + alpha) ** beta * math.exp(-decay_per_day * age_days)
+
+
+def choose(
+    memories: list[TermMemory],
+    now: float,
+    rng: random.Random | None = None,
+) -> TermMemory | None:
+    if not memories:
+        return None
+    random_source = rng or random.Random()
+    weights = [weight(memory, now) for memory in memories]
+    return random_source.choices(memories, weights=weights, k=1)[0]
+
+
+def katakana(text: str) -> str:
+    chars = []
+    for char in text:
+        code = ord(char)
+        chars.append(chr(code + 0x60) if 0x3041 <= code <= 0x3096 else char)
+    return "".join(chars)
+
+
+def encode_reading(reading: str, slots: int = 8) -> list[int]:
+    values = [KANA_TO_INT.get(char, 0) for char in katakana(reading)[:slots]]
+    return values + [0] * (slots - len(values))
+
+
+def synced_parameter_bits(slots: int = 8) -> int:
+    return slots * 8 + 8 + 1

--- a/tests/test_companion_projection.py
+++ b/tests/test_companion_projection.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import random
+import struct
+
+from vlog_companion import (
+    TermMemory,
+    choose,
+    encode_reading,
+    observe,
+    synced_parameter_bits,
+    weight,
+)
+from vlog_vrchat_osc import osc_message
+
+
+def test_observe_increments_frequency() -> None:
+    state: dict[str, TermMemory] = {}
+    observe(state, "猫", "ネコ", 100.0)
+    memory = observe(state, "猫", "ネコ", 200.0)
+    assert memory.count == 2
+    assert memory.last_seen == 200.0
+
+
+def test_weight_prefers_frequency_and_recency() -> None:
+    now = 10 * 86400.0
+    frequent = TermMemory("猫", "ネコ", 5, now)
+    rare = TermMemory("犬", "イヌ", 1, now)
+    old = TermMemory("鳥", "トリ", 5, 0.0)
+    assert weight(frequent, now) > weight(rare, now)
+    assert weight(frequent, now) > weight(old, now)
+
+
+def test_choose_returns_observed_memory() -> None:
+    memory = TermMemory("猫", "ネコ", 1, 0.0)
+    assert choose([memory], 0.0, random.Random(1)) == memory
+
+
+def test_kana_encoding_and_parameter_budget() -> None:
+    assert encode_reading("ねこ")[:2] == encode_reading("ネコ")[:2]
+    assert len(encode_reading("ネコ")) == 8
+    assert synced_parameter_bits() == 73
+
+
+def test_osc_packets_match_vrchat_parameter_shape() -> None:
+    int_packet = osc_message("/avatar/parameters/PetChar0", 7)
+    bool_packet = osc_message("/avatar/parameters/PetSpeak", True)
+    assert int_packet.endswith(struct.pack(">i", 7))
+    assert b",i\0" in int_packet
+    assert b",T\0" in bool_packet


### PR DESCRIPTION
## Purpose
Move the local-learning VRChat pet concept into VLog, where VRChat voice/memory/public-projection boundaries already exist.

## Architecture
- `packages/companion`: storage-agnostic frequency/recency memory model and 8-slot kana encoding
- `adapters/vrchat-osc`: replaceable UDP OSC output for Avatar Parameters
- `apps/companion-lab`: static browser demo intended for GitHub Pages

## Privacy boundary
The companion is a rebuildable projection. It does not accept human memory claims and the public demo does not load raw audio, full transcripts, journals, people data, or credentials. Demo state stays in browser localStorage only.

## Protocol
`PetChar0..7` (8-bit each) + `PetMood` (8-bit) + `PetSpeak` (1-bit) = 73 synced bits.

## Verification
- repository Python CI compiles/lints `packages` and `adapters`
- pytest covers observation count, frequency/recency weighting, kana encoding, 73-bit budget, and OSC packet shape
- Pages workflow validates HTML/JS and deploys only after repository Pages is enabled

## GitHub Pages
The repository currently returns 404 from the Pages configuration endpoint, so Pages is not enabled yet. After merge, one repository setting is required: Settings → Pages → Source: GitHub Actions. The workflow then deploys and smoke-checks the public URL.

## Primary references
- https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages
- https://docs.github.com/en/rest/pages/pages?apiVersion=2022-11-28
- https://docs.vrchat.com/docs/osc-overview
- https://creators.vrchat.com/avatars/animator-parameters/