### PR TITLE
feat: ingest VRCPet/Muchio as private Human Memory observation source

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
 
       - run: uv sync --only-group dev
       - run: uv run ruff check apps/capture-vrchat/src packages scripts tests infra/systemd
-      - name: Show exact Ruff formatter diff for Issue 27
-        run: uv run ruff format --diff tests/test_vrcpet_adapter.py || true
+      - run: uv run ruff format --check apps/capture-vrchat/src packages scripts tests infra/systemd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,5 @@ jobs:
 
       - run: uv sync --only-group dev
       - run: uv run ruff check apps/capture-vrchat/src packages scripts tests infra/systemd
-      - run: uv run ruff format --check apps/capture-vrchat/src packages scripts tests infra/systemd
+      - name: Show exact Ruff formatter diff for Issue 27
+        run: uv run ruff format --diff tests/test_vrcpet_adapter.py || true

--- a/adapters/vrcpet/README.md
+++ b/adapters/vrcpet/README.md
@@ -1,0 +1,42 @@
+# VRCPet / Muchio private observation adapter
+
+This adapter ingests files produced by VRCPet/Muchio as a **private observation source** for Human Memory v2. It is an external-data boundary, not a second diary generator and not an extension of `packages/companion`.
+
+## Boundary
+
+- The VRCPet source directory is read-only. This adapter exposes no write/delete operation for it.
+- The executable itself is not inspected, modified, or redistributed.
+- Source roots are configurable and may be restricted by an explicit allowlist. A particular Windows path or filename layout is treated as an observed input layout, not as a vendor-guaranteed API.
+- Windows absolute paths and user names are never copied into canonical manifests. Only source-relative paths are retained.
+- Raw bytes are hashed with SHA-256 before normalization. Content-addressed deterministic UUIDs make identical observations idempotent.
+- Conversation JSONL becomes `SourceKind.CONVERSATION`; profile, vocabulary, and operational state becomes `SourceKind.DOCUMENT`.
+- `profile.json` and `heard_nouns.json` are companion state. They do not create or accept human `MemoryClaim` objects.
+- Malformed lines and schema drift are isolated into parse/audit issues instead of being silently discarded.
+- Exact state bytes can be handed to private persistence as immutable daily snapshot candidates. The public repository must never contain real private snapshot payloads.
+
+## Supported observed inputs
+
+```text
+<configured-root>/
+├─ logs/**/*.jsonl
+├─ pet.log
+├─ profile.json
+└─ heard_nouns.json
+```
+
+The reader only discovers these names/patterns. Unknown vendor fields remain in the parsed record and therefore remain recoverable from the raw source.
+
+## Flow
+
+```text
+read-only SourceFile
+  -> tolerant parse
+  -> SHA-256 + deterministic UUID
+  -> SourceObject + source manifest
+  -> IngestionRun(source_hash + pipeline_version)
+  -> immutable profile/vocabulary snapshot candidate
+  -> Episode association
+  -> rebuildable companion daily view ("すいの目から見た1日")
+```
+
+`pipeline_version` belongs to `IngestionRun`; VRCPet-specific path/provenance details remain in manifest metadata. The existing `schemas/source-manifest.schema.json` contract is reused rather than introducing a VRCPet-specific canonical schema.

--- a/adapters/vrcpet/__init__.py
+++ b/adapters/vrcpet/__init__.py
@@ -1,0 +1,52 @@
+"""VRCPet/Muchio private observation adapter for Human Memory v2."""
+
+from .daily_view import CompanionDailyView, build_companion_daily_view
+from .normalizer import (
+    NormalizedObservation,
+    associate_episode,
+    build_ingestion_run,
+    deduplicate_observations,
+    normalize_source,
+)
+from .parser import ParseIssue, ParsedObservation, parse_observation
+from .reader import (
+    SourceBoundaryError,
+    SourceFile,
+    UnstableSourceError,
+    discover_source_paths,
+    read_source_file,
+    validate_source_root,
+)
+from .snapshot import (
+    ProfileDiff,
+    StateSnapshot,
+    VocabularyDiff,
+    build_state_snapshot,
+    diff_profile,
+    diff_vocabulary_counts,
+)
+
+__all__ = [
+    "CompanionDailyView",
+    "NormalizedObservation",
+    "ParseIssue",
+    "ParsedObservation",
+    "ProfileDiff",
+    "SourceBoundaryError",
+    "SourceFile",
+    "StateSnapshot",
+    "UnstableSourceError",
+    "VocabularyDiff",
+    "associate_episode",
+    "build_companion_daily_view",
+    "build_ingestion_run",
+    "build_state_snapshot",
+    "deduplicate_observations",
+    "diff_profile",
+    "diff_vocabulary_counts",
+    "discover_source_paths",
+    "normalize_source",
+    "parse_observation",
+    "read_source_file",
+    "validate_source_root",
+]

--- a/adapters/vrcpet/__init__.py
+++ b/adapters/vrcpet/__init__.py
@@ -24,6 +24,7 @@ from .snapshot import (
     build_state_snapshot,
     diff_profile,
     diff_vocabulary_counts,
+    extract_vocabulary_counts,
 )
 
 __all__ = [
@@ -45,6 +46,7 @@ __all__ = [
     "diff_profile",
     "diff_vocabulary_counts",
     "discover_source_paths",
+    "extract_vocabulary_counts",
     "normalize_source",
     "parse_observation",
     "read_source_file",

--- a/adapters/vrcpet/__init__.py
+++ b/adapters/vrcpet/__init__.py
@@ -8,7 +8,7 @@ from .normalizer import (
     deduplicate_observations,
     normalize_source,
 )
-from .parser import ParseIssue, ParsedObservation, parse_observation
+from .parser import ParsedObservation, ParseIssue, parse_observation
 from .reader import (
     SourceBoundaryError,
     SourceFile,

--- a/adapters/vrcpet/daily_view.py
+++ b/adapters/vrcpet/daily_view.py
@@ -6,7 +6,12 @@ from numbers import Real
 from typing import Iterable, Mapping, Sequence
 
 from .normalizer import NormalizedObservation
-from .snapshot import ProfileDiff, StateSnapshot, VocabularyDiff
+from .snapshot import (
+    ProfileDiff,
+    StateSnapshot,
+    VocabularyDiff,
+    extract_vocabulary_counts,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +55,18 @@ class CompanionDailyView:
         )
 
 
+def _counts_from_observations(
+    observations: tuple[NormalizedObservation, ...],
+) -> Mapping[str, Real]:
+    for observation in observations:
+        if observation.parsed.observation_type != "vocabulary":
+            continue
+        if not observation.parsed.records:
+            continue
+        return extract_vocabulary_counts(observation.parsed.records[0])
+    return {}
+
+
 def build_companion_daily_view(
     *,
     day: date,
@@ -74,7 +91,7 @@ def build_companion_daily_view(
     )
     parse_issues = sum(len(item.parsed.issues) for item in observed)
 
-    counts = current_counts or {}
+    counts = current_counts if current_counts is not None else _counts_from_observations(observed)
     frequent_terms = tuple(
         sorted(
             (

--- a/adapters/vrcpet/daily_view.py
+++ b/adapters/vrcpet/daily_view.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from numbers import Real
+from typing import Iterable, Mapping, Sequence
+
+from .normalizer import NormalizedObservation
+from .snapshot import ProfileDiff, StateSnapshot, VocabularyDiff
+
+
+@dataclass(frozen=True, slots=True)
+class CompanionDailyView:
+    day: date
+    conversation_records: int
+    operational_records: int
+    parse_issues: int
+    snapshots: int
+    frequent_terms: tuple[tuple[str, Real], ...]
+    newly_learned_terms: tuple[str, ...]
+    strengthened_terms: tuple[str, ...]
+    weakened_or_missing_terms: tuple[str, ...]
+    pet_utterances: tuple[str, ...]
+    profile_changes: tuple[str, ...]
+
+    def render_markdown(self, *, pet_name: str = "すい") -> str:
+        def joined(values: Sequence[str]) -> str:
+            return "、".join(values) if values else "なし"
+
+        frequent = (
+            "、".join(f"{term}({count})" for term, count in self.frequent_terms)
+            if self.frequent_terms
+            else "なし"
+        )
+        return "\n".join(
+            (
+                f"# {pet_name}の目から見た{self.day.isoformat()}",
+                "",
+                f"- 会話観測: {self.conversation_records}件",
+                f"- operational observation: {self.operational_records}件",
+                f"- state snapshot: {self.snapshots}件",
+                f"- parse isolation/audit: {self.parse_issues}件",
+                f"- よく聞いた言葉: {frequent}",
+                f"- 新しく覚えた言葉: {joined(self.newly_learned_terms)}",
+                f"- 強くなった言葉: {joined(self.strengthened_terms)}",
+                f"- 弱くなった/消えた言葉: {joined(self.weakened_or_missing_terms)}",
+                f"- ムチォ側の発話: {joined(self.pet_utterances)}",
+                f"- profile変化: {joined(self.profile_changes)}",
+            )
+        )
+
+
+def build_companion_daily_view(
+    *,
+    day: date,
+    observations: Iterable[NormalizedObservation],
+    snapshots: Iterable[StateSnapshot] = (),
+    current_counts: Mapping[str, Real] | None = None,
+    vocabulary_diff: VocabularyDiff | None = None,
+    profile_diff: ProfileDiff | None = None,
+    pet_utterances: Sequence[str] = (),
+) -> CompanionDailyView:
+    observed = tuple(observations)
+    snapshot_items = tuple(snapshots)
+    conversation_records = sum(
+        len(item.parsed.records)
+        for item in observed
+        if item.parsed.observation_type == "conversation"
+    )
+    operational_records = sum(
+        len(item.parsed.records)
+        for item in observed
+        if item.parsed.observation_type == "operational"
+    )
+    parse_issues = sum(len(item.parsed.issues) for item in observed)
+
+    counts = current_counts or {}
+    frequent_terms = tuple(
+        sorted(
+            (
+                (key, value)
+                for key, value in counts.items()
+                if isinstance(value, Real) and not isinstance(value, bool)
+            ),
+            key=lambda item: (-item[1], item[0]),
+        )[:10]
+    )
+    if vocabulary_diff is None:
+        new_terms: tuple[str, ...] = ()
+        strengthened_terms: tuple[str, ...] = ()
+        weakened_terms: tuple[str, ...] = ()
+    else:
+        new_terms = tuple(sorted(vocabulary_diff.new))
+        strengthened_terms = tuple(sorted(vocabulary_diff.increased))
+        weakened_terms = tuple(
+            sorted(set(vocabulary_diff.decreased) | set(vocabulary_diff.missing))
+        )
+
+    if profile_diff is None:
+        profile_changes: tuple[str, ...] = ()
+    else:
+        profile_changes = tuple(
+            sorted(
+                set(profile_diff.added)
+                | set(profile_diff.removed)
+                | set(profile_diff.changed)
+            )
+        )
+
+    return CompanionDailyView(
+        day=day,
+        conversation_records=conversation_records,
+        operational_records=operational_records,
+        parse_issues=parse_issues,
+        snapshots=len(snapshot_items),
+        frequent_terms=frequent_terms,
+        newly_learned_terms=new_terms,
+        strengthened_terms=strengthened_terms,
+        weakened_or_missing_terms=weakened_terms,
+        pet_utterances=tuple(pet_utterances),
+        profile_changes=profile_changes,
+    )

--- a/adapters/vrcpet/normalizer.py
+++ b/adapters/vrcpet/normalizer.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Iterable, Mapping
+from uuid import UUID, uuid5
+
+from vlog_memory_domain import (
+    Episode,
+    IngestionRun,
+    IngestionStatus,
+    PrivacyLevel,
+    SourceKind,
+    SourceObject,
+)
+
+from .parser import ParsedObservation
+from .reader import SourceFile
+
+
+VRC_PET_NAMESPACE = UUID("7b042afa-2563-5c4f-81c5-f35fd0f7c7cc")
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedObservation:
+    source_object: SourceObject
+    manifest: Mapping[str, Any]
+    parsed: ParsedObservation
+    raw_bytes: bytes
+
+    @property
+    def source_hash(self) -> str:
+        return self.source_object.sha256
+
+
+def _source_kind(observation_type: str) -> SourceKind:
+    if observation_type == "conversation":
+        return SourceKind.CONVERSATION
+    return SourceKind.DOCUMENT
+
+
+def normalize_source(
+    source: SourceFile,
+    parsed: ParsedObservation,
+) -> NormalizedObservation:
+    digest = sha256(source.raw_bytes).hexdigest()
+    kind = _source_kind(parsed.observation_type)
+    source_id = str(uuid5(VRC_PET_NAMESPACE, f"{parsed.observation_type}:{digest}"))
+    recorded_at = datetime.fromtimestamp(source.mtime_ns / 1_000_000_000, timezone.utc)
+    object_uri = f"private://vrcpet/{parsed.observation_type}/sha256/{digest}"
+
+    source_object = SourceObject(
+        id=source_id,
+        kind=kind,
+        object_uri=object_uri,
+        sha256=digest,
+        size_bytes=source.size_bytes,
+        recorded_at=recorded_at,
+        privacy=PrivacyLevel.PRIVATE,
+    )
+    manifest = {
+        "id": source_object.id,
+        "kind": source_object.kind.value,
+        "object_uri": source_object.object_uri,
+        "sha256": source_object.sha256,
+        "size_bytes": source_object.size_bytes,
+        "recorded_at": source_object.recorded_at.isoformat(),
+        "privacy": source_object.privacy.value,
+        "original_filename": source.relative_path.rsplit("/", 1)[-1],
+        "metadata": {
+            "source": "vrcpet",
+            "observation_type": parsed.observation_type,
+            "source_relative_path": source.relative_path,
+            "source_mtime_ns": source.mtime_ns,
+            "parse_issue_count": len(parsed.issues),
+        },
+    }
+    return NormalizedObservation(
+        source_object=source_object,
+        manifest=manifest,
+        parsed=parsed,
+        raw_bytes=source.raw_bytes,
+    )
+
+
+def deduplicate_observations(
+    observations: Iterable[NormalizedObservation],
+) -> tuple[NormalizedObservation, ...]:
+    by_id: dict[str, NormalizedObservation] = {}
+    for observation in observations:
+        by_id.setdefault(observation.source_object.id, observation)
+    return tuple(by_id.values())
+
+
+def build_ingestion_run(
+    observation: NormalizedObservation,
+    *,
+    pipeline_version: str,
+    at: datetime | None = None,
+) -> IngestionRun:
+    timestamp = at or datetime.now(timezone.utc)
+    return IngestionRun(
+        source_hash=observation.source_hash,
+        pipeline_version=pipeline_version,
+        status=IngestionStatus.SUCCEEDED,
+        started_at=timestamp,
+        completed_at=timestamp,
+    )
+
+
+def associate_episode(
+    episode: Episode,
+    observations: Iterable[NormalizedObservation],
+) -> Episode:
+    source_ids = list(episode.source_object_ids)
+    for observation in observations:
+        source_id = observation.source_object.id
+        if source_id not in source_ids:
+            source_ids.append(source_id)
+    return Episode(
+        id=episode.id,
+        started_at=episode.started_at,
+        ended_at=episode.ended_at,
+        source_object_ids=tuple(source_ids),
+        title=episode.title,
+    )

--- a/adapters/vrcpet/normalizer.py
+++ b/adapters/vrcpet/normalizer.py
@@ -18,7 +18,6 @@ from vlog_memory_domain import (
 from .parser import ParsedObservation
 from .reader import SourceFile
 
-
 VRC_PET_NAMESPACE = UUID("7b042afa-2563-5c4f-81c5-f35fd0f7c7cc")
 
 

--- a/adapters/vrcpet/normalizer.py
+++ b/adapters/vrcpet/normalizer.py
@@ -14,6 +14,7 @@ from vlog_memory_domain import (
     SourceKind,
     SourceObject,
 )
+
 from .parser import ParsedObservation
 from .reader import SourceFile
 

--- a/adapters/vrcpet/normalizer.py
+++ b/adapters/vrcpet/normalizer.py
@@ -14,7 +14,6 @@ from vlog_memory_domain import (
     SourceKind,
     SourceObject,
 )
-
 from .parser import ParsedObservation
 from .reader import SourceFile
 

--- a/adapters/vrcpet/parser.py
+++ b/adapters/vrcpet/parser.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ParseIssue:
+    code: str
+    message: str
+    line_number: int | None = None
+    raw_fragment: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedObservation:
+    observation_type: str
+    records: tuple[dict[str, Any], ...]
+    issues: tuple[ParseIssue, ...] = ()
+
+
+def _decode(raw_bytes: bytes) -> tuple[str, list[ParseIssue]]:
+    text = raw_bytes.decode("utf-8", errors="replace")
+    issues: list[ParseIssue] = []
+    if "\ufffd" in text:
+        issues.append(
+            ParseIssue(
+                code="invalid_utf8",
+                message="invalid UTF-8 bytes were replaced while parsing",
+            )
+        )
+    return text, issues
+
+
+def _parse_jsonl(text: str, issues: list[ParseIssue]) -> tuple[dict[str, Any], ...]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            issues.append(
+                ParseIssue(
+                    code="malformed_jsonl_line",
+                    message=str(exc),
+                    line_number=line_number,
+                    raw_fragment=line,
+                )
+            )
+            continue
+        if isinstance(value, dict):
+            records.append(value)
+        else:
+            issues.append(
+                ParseIssue(
+                    code="non_object_jsonl_record",
+                    message="JSONL record was preserved under the value key",
+                    line_number=line_number,
+                    raw_fragment=line,
+                )
+            )
+            records.append({"value": value})
+    return tuple(records)
+
+
+def _parse_document(text: str, issues: list[ParseIssue]) -> tuple[dict[str, Any], ...]:
+    if not text.strip():
+        return ()
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        issues.append(
+            ParseIssue(
+                code="malformed_json_document",
+                message=str(exc),
+                raw_fragment=text,
+            )
+        )
+        return ()
+    if isinstance(value, dict):
+        return (value,)
+    issues.append(
+        ParseIssue(
+            code="non_object_json_document",
+            message="JSON document was preserved under the value key",
+        )
+    )
+    return ({"value": value},)
+
+
+def _parse_pet_log(text: str, issues: list[ParseIssue]) -> tuple[dict[str, Any], ...]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        stripped = line.strip()
+        if stripped.startswith(("{", "[")):
+            try:
+                value = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                issues.append(
+                    ParseIssue(
+                        code="malformed_pet_log_json",
+                        message=str(exc),
+                        line_number=line_number,
+                        raw_fragment=line,
+                    )
+                )
+                records.append({"raw_text": line})
+                continue
+            if isinstance(value, dict):
+                records.append(value)
+            else:
+                records.append({"value": value})
+        else:
+            records.append({"raw_text": line})
+    return tuple(records)
+
+
+def parse_observation(relative_path: str, raw_bytes: bytes) -> ParsedObservation:
+    name = Path(relative_path).name.lower()
+    text, issues = _decode(raw_bytes)
+
+    if name == "profile.json":
+        return ParsedObservation(
+            observation_type="profile",
+            records=_parse_document(text, issues),
+            issues=tuple(issues),
+        )
+    if name == "heard_nouns.json":
+        return ParsedObservation(
+            observation_type="vocabulary",
+            records=_parse_document(text, issues),
+            issues=tuple(issues),
+        )
+    if name == "pet.log":
+        return ParsedObservation(
+            observation_type="operational",
+            records=_parse_pet_log(text, issues),
+            issues=tuple(issues),
+        )
+    if name.endswith(".jsonl"):
+        return ParsedObservation(
+            observation_type="conversation",
+            records=_parse_jsonl(text, issues),
+            issues=tuple(issues),
+        )
+    raise ValueError(f"unsupported VRCPet source file: {relative_path}")

--- a/adapters/vrcpet/reader.py
+++ b/adapters/vrcpet/reader.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+class SourceBoundaryError(ValueError):
+    """Raised when a source path escapes the configured read-only boundary."""
+
+
+class UnstableSourceError(RuntimeError):
+    """Raised when a source changes while it is being read."""
+
+
+@dataclass(frozen=True, slots=True)
+class SourceFile:
+    relative_path: str
+    raw_bytes: bytes
+    size_bytes: int
+    mtime_ns: int
+
+
+def _contains(parent: Path, child: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_source_root(
+    root: str | Path,
+    *,
+    allowlisted_roots: Iterable[str | Path] = (),
+) -> Path:
+    resolved = Path(root).expanduser().resolve(strict=True)
+    if not resolved.is_dir():
+        raise SourceBoundaryError("VRCPet source root must be a directory")
+
+    allowed = tuple(
+        Path(item).expanduser().resolve(strict=True) for item in allowlisted_roots
+    )
+    if allowed and not any(_contains(base, resolved) for base in allowed):
+        raise SourceBoundaryError("VRCPet source root is outside the allowlist")
+    return resolved
+
+
+def discover_source_paths(root: str | Path) -> tuple[str, ...]:
+    source_root = Path(root)
+    discovered: set[str] = set()
+
+    logs_dir = source_root / "logs"
+    if logs_dir.is_dir():
+        for path in logs_dir.rglob("*.jsonl"):
+            if path.is_file():
+                discovered.add(path.relative_to(source_root).as_posix())
+
+    for filename in ("pet.log", "profile.json", "heard_nouns.json"):
+        path = source_root / filename
+        if path.is_file():
+            discovered.add(filename)
+
+    return tuple(sorted(discovered))
+
+
+def read_source_file(
+    root: str | Path,
+    relative_path: str | Path,
+    *,
+    allowlisted_roots: Iterable[str | Path] = (),
+) -> SourceFile:
+    source_root = validate_source_root(root, allowlisted_roots=allowlisted_roots)
+    relative = Path(relative_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise SourceBoundaryError("source path must be relative to the configured root")
+
+    path = (source_root / relative).resolve(strict=True)
+    if not _contains(source_root, path) or not path.is_file():
+        raise SourceBoundaryError("source file escapes the configured root")
+
+    before = path.stat()
+    raw_bytes = path.read_bytes()
+    after = path.stat()
+    if (
+        before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or len(raw_bytes) != after.st_size
+    ):
+        raise UnstableSourceError(f"source changed while reading: {relative.as_posix()}")
+
+    return SourceFile(
+        relative_path=relative.as_posix(),
+        raw_bytes=raw_bytes,
+        size_bytes=len(raw_bytes),
+        mtime_ns=after.st_mtime_ns,
+    )

--- a/adapters/vrcpet/snapshot.py
+++ b/adapters/vrcpet/snapshot.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from numbers import Real
+from typing import Any, Mapping
+
+from .normalizer import NormalizedObservation
+
+
+@dataclass(frozen=True, slots=True)
+class StateSnapshot:
+    captured_on: date
+    observation_type: str
+    source_object_id: str
+    sha256: str
+    object_uri: str
+    raw_bytes: bytes
+
+    @property
+    def idempotency_key(self) -> str:
+        return f"{self.captured_on.isoformat()}:{self.observation_type}:{self.sha256}"
+
+
+@dataclass(frozen=True, slots=True)
+class VocabularyDiff:
+    new: Mapping[str, Real]
+    increased: Mapping[str, tuple[Real, Real]]
+    decreased: Mapping[str, tuple[Real, Real]]
+    missing: Mapping[str, Real]
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileDiff:
+    added: Mapping[str, Any]
+    removed: Mapping[str, Any]
+    changed: Mapping[str, tuple[Any, Any]]
+
+
+def build_state_snapshot(
+    observation: NormalizedObservation,
+    *,
+    captured_on: date,
+) -> StateSnapshot:
+    observation_type = observation.parsed.observation_type
+    if observation_type not in {"profile", "vocabulary"}:
+        raise ValueError("only profile/vocabulary observations are state snapshots")
+    return StateSnapshot(
+        captured_on=captured_on,
+        observation_type=observation_type,
+        source_object_id=observation.source_object.id,
+        sha256=observation.source_hash,
+        object_uri=(
+            "private://vrcpet/snapshots/"
+            f"{captured_on.isoformat()}/{observation_type}/"
+            f"{observation.source_hash}"
+        ),
+        raw_bytes=observation.raw_bytes,
+    )
+
+
+def diff_vocabulary_counts(
+    previous: Mapping[str, Real],
+    current: Mapping[str, Real],
+) -> VocabularyDiff:
+    def numeric_items(values: Mapping[str, Real]) -> dict[str, Real]:
+        return {
+            key: value
+            for key, value in values.items()
+            if isinstance(value, Real) and not isinstance(value, bool)
+        }
+
+    before = numeric_items(previous)
+    after = numeric_items(current)
+    new = {key: after[key] for key in after.keys() - before.keys()}
+    missing = {key: before[key] for key in before.keys() - after.keys()}
+    increased = {
+        key: (before[key], after[key])
+        for key in before.keys() & after.keys()
+        if after[key] > before[key]
+    }
+    decreased = {
+        key: (before[key], after[key])
+        for key in before.keys() & after.keys()
+        if after[key] < before[key]
+    }
+    return VocabularyDiff(
+        new=new,
+        increased=increased,
+        decreased=decreased,
+        missing=missing,
+    )
+
+
+def diff_profile(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> ProfileDiff:
+    added = {key: current[key] for key in current.keys() - previous.keys()}
+    removed = {key: previous[key] for key in previous.keys() - current.keys()}
+    changed = {
+        key: (previous[key], current[key])
+        for key in previous.keys() & current.keys()
+        if previous[key] != current[key]
+    }
+    return ProfileDiff(added=added, removed=removed, changed=changed)

--- a/adapters/vrcpet/snapshot.py
+++ b/adapters/vrcpet/snapshot.py
@@ -59,6 +59,29 @@ def build_state_snapshot(
     )
 
 
+def extract_vocabulary_counts(document: Mapping[str, Any]) -> dict[str, Real]:
+    """Extract projection counts without turning the observed vendor shape canonical."""
+
+    words = document.get("words")
+    if isinstance(words, Mapping):
+        counts: dict[str, Real] = {}
+        for term, payload in words.items():
+            if not isinstance(term, str) or not isinstance(payload, Mapping):
+                continue
+            count = payload.get("count")
+            if isinstance(count, Real) and not isinstance(count, bool):
+                counts[term] = count
+        return counts
+
+    return {
+        key: value
+        for key, value in document.items()
+        if isinstance(key, str)
+        and isinstance(value, Real)
+        and not isinstance(value, bool)
+    }
+
+
 def diff_vocabulary_counts(
     previous: Mapping[str, Real],
     current: Mapping[str, Real],

--- a/tests/test_vrcpet_adapter.py
+++ b/tests/test_vrcpet_adapter.py
@@ -229,7 +229,8 @@ def test_state_snapshot_retains_exact_bytes_and_diff_is_explicit() -> None:
     assert vocabulary_delta.missing == {"old": 1}
 
 
-def test_observation_associates_with_existing_episode_without_memory_claim_promotion() -> None:
+def test_observation_associates_with_existing_episode_without_memory_claim_promotion(
+) -> None:
     primary = SourceObject(
         kind=SourceKind.AUDIO,
         object_uri="private://audio/session.flac",

--- a/tests/test_vrcpet_adapter.py
+++ b/tests/test_vrcpet_adapter.py
@@ -11,6 +11,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "packages" / "memory-domain" / "src"))
 
+from vlog_memory_domain import (  # noqa: E402
+    Episode,
+    PrivacyLevel,
+    SourceKind,
+    SourceObject,
+)
+
 import adapters.vrcpet.normalizer as normalizer_module  # noqa: E402
 from adapters.vrcpet import (  # noqa: E402
     SourceBoundaryError,
@@ -28,12 +35,6 @@ from adapters.vrcpet import (  # noqa: E402
     normalize_source,
     parse_observation,
     read_source_file,
-)
-from vlog_memory_domain import (  # noqa: E402
-    Episode,
-    PrivacyLevel,
-    SourceKind,
-    SourceObject,
 )
 
 

--- a/tests/test_vrcpet_adapter.py
+++ b/tests/test_vrcpet_adapter.py
@@ -4,7 +4,6 @@ import json
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
@@ -25,6 +24,7 @@ from adapters.vrcpet import (  # noqa: E402
     diff_profile,
     diff_vocabulary_counts,
     discover_source_paths,
+    extract_vocabulary_counts,
     normalize_source,
     parse_observation,
     read_source_file,
@@ -37,7 +37,12 @@ from vlog_memory_domain import (  # noqa: E402
 )
 
 
-def _source(relative_path: str, raw_bytes: bytes, *, mtime_ns: int = 1_700_000_000_000_000_000) -> SourceFile:
+def _source(
+    relative_path: str,
+    raw_bytes: bytes,
+    *,
+    mtime_ns: int = 1_700_000_000_000_000_000,
+) -> SourceFile:
     return SourceFile(
         relative_path=relative_path,
         raw_bytes=raw_bytes,
@@ -132,7 +137,7 @@ def test_discovery_is_limited_to_observed_vrcpet_inputs(tmp_path: Path) -> None:
     )
 
 
-def test_normalization_is_content_addressed_and_sanitizes_absolute_path(tmp_path: Path) -> None:
+def test_normalization_is_content_addressed_and_sanitizes_absolute_path() -> None:
     raw = b'{"text":"same"}\n'
     first = normalize_source(
         _source("logs/a.jsonl", raw),
@@ -152,7 +157,7 @@ def test_normalization_is_content_addressed_and_sanitizes_absolute_path(tmp_path
     assert first.source_object.id != changed.source_object.id
     assert first.source_object.object_uri.startswith("private://vrcpet/conversation/")
     manifest_text = json.dumps(first.manifest, ensure_ascii=False)
-    assert str(tmp_path) not in manifest_text
+    assert "C:\\Users\\" not in manifest_text
     assert first.manifest["metadata"]["source_relative_path"] == "logs/a.jsonl"
 
 
@@ -178,6 +183,21 @@ def test_duplicate_ingest_and_pipeline_version_are_idempotent() -> None:
     )
 
 
+def test_observed_nested_vocabulary_shape_extracts_counts_only_for_projection() -> None:
+    document = {
+        "words": {
+            "旅行": {"kind": "noun", "count": 5, "F": 1.5},
+            "GPU": {"kind": "noun", "count": 3, "S": 2.0},
+            "bad": {"kind": "noun", "count": "unknown"},
+        },
+        "total_learned": 1465,
+        "unknown_future_field": {"preserved": True},
+    }
+
+    assert extract_vocabulary_counts(document) == {"旅行": 5, "GPU": 3}
+    assert document["unknown_future_field"] == {"preserved": True}
+
+
 def test_state_snapshot_retains_exact_bytes_and_diff_is_explicit() -> None:
     profile_raw = b'{"favorite":"blue","mood":"curious"}'
     profile = normalize_source(
@@ -187,7 +207,9 @@ def test_state_snapshot_retains_exact_bytes_and_diff_is_explicit() -> None:
     snapshot = build_state_snapshot(profile, captured_on=date(2026, 8, 12))
 
     assert snapshot.raw_bytes == profile_raw
-    assert snapshot.object_uri.startswith("private://vrcpet/snapshots/2026-08-12/profile/")
+    assert snapshot.object_uri.startswith(
+        "private://vrcpet/snapshots/2026-08-12/profile/"
+    )
     profile_delta = diff_profile(
         {"favorite": "blue", "mood": "calm", "old": True},
         {"favorite": "blue", "mood": "curious", "new": 1},
@@ -235,7 +257,17 @@ def test_observation_associates_with_existing_episode_without_memory_claim_promo
 def test_end_to_end_daily_companion_view_is_rebuildable() -> None:
     conversation_raw = b'{"text":"travel"}\n{"broken":\n{"text":"Kyoto"}\n'
     profile_raw = b'{"favorite":"blue","mood":"curious"}'
-    vocabulary_raw = '{"旅行":5,"GPU":3,"京都":1}'.encode()
+    vocabulary_raw = json.dumps(
+        {
+            "words": {
+                "旅行": {"kind": "noun", "count": 5},
+                "GPU": {"kind": "noun", "count": 3},
+                "京都": {"kind": "noun", "count": 1},
+            },
+            "total_learned": 3,
+        },
+        ensure_ascii=False,
+    ).encode()
 
     conversation = normalize_source(
         _source("logs/2026-08-12.jsonl", conversation_raw),
@@ -266,7 +298,6 @@ def test_end_to_end_daily_companion_view_is_rebuildable() -> None:
         day=date(2026, 8, 12),
         observations=(conversation, profile, vocabulary),
         snapshots=snapshots,
-        current_counts={"旅行": 5, "GPU": 3, "京都": 1},
         vocabulary_diff=vocabulary_delta,
         profile_diff=profile_delta,
         pet_utterances=("こんにちは",),
@@ -276,6 +307,7 @@ def test_end_to_end_daily_companion_view_is_rebuildable() -> None:
     assert view.conversation_records == 2
     assert view.parse_issues == 1
     assert view.snapshots == 2
+    assert view.frequent_terms[0] == ("旅行", 5)
     assert "# すいの目から見た2026-08-12" in rendered
     assert "京都" in rendered
     assert "mood" in rendered

--- a/tests/test_vrcpet_adapter.py
+++ b/tests/test_vrcpet_adapter.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "packages" / "memory-domain" / "src"))
+
+import adapters.vrcpet.normalizer as normalizer_module  # noqa: E402
+from adapters.vrcpet import (  # noqa: E402
+    SourceBoundaryError,
+    SourceFile,
+    UnstableSourceError,
+    associate_episode,
+    build_companion_daily_view,
+    build_ingestion_run,
+    build_state_snapshot,
+    deduplicate_observations,
+    diff_profile,
+    diff_vocabulary_counts,
+    discover_source_paths,
+    normalize_source,
+    parse_observation,
+    read_source_file,
+)
+from vlog_memory_domain import (  # noqa: E402
+    Episode,
+    PrivacyLevel,
+    SourceKind,
+    SourceObject,
+)
+
+
+def _source(relative_path: str, raw_bytes: bytes, *, mtime_ns: int = 1_700_000_000_000_000_000) -> SourceFile:
+    return SourceFile(
+        relative_path=relative_path,
+        raw_bytes=raw_bytes,
+        size_bytes=len(raw_bytes),
+        mtime_ns=mtime_ns,
+    )
+
+
+def test_jsonl_malformed_line_is_isolated_without_losing_valid_records() -> None:
+    parsed = parse_observation(
+        "logs/2026-08-12.jsonl",
+        b'{"text":"hello"}\n{"broken":\n{"text":"world"}\n',
+    )
+
+    assert [record["text"] for record in parsed.records] == ["hello", "world"]
+    assert len(parsed.issues) == 1
+    assert parsed.issues[0].code == "malformed_jsonl_line"
+    assert parsed.issues[0].line_number == 2
+
+
+def test_empty_source_is_valid_and_produces_no_records() -> None:
+    parsed = parse_observation("logs/empty.jsonl", b"")
+    assert parsed.records == ()
+    assert parsed.issues == ()
+
+
+def test_pet_log_preserves_unknown_text_and_malformed_json() -> None:
+    parsed = parse_observation(
+        "pet.log",
+        b'plain operational line\n{"event":"ok"}\n{"broken":\n',
+    )
+
+    assert parsed.records[0] == {"raw_text": "plain operational line"}
+    assert parsed.records[1] == {"event": "ok"}
+    assert parsed.records[2]["raw_text"] == '{"broken":'
+    assert parsed.issues[0].code == "malformed_pet_log_json"
+
+
+def test_source_root_allowlist_and_path_escape_are_rejected(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "profile.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(SourceBoundaryError, match="allowlist"):
+        read_source_file(
+            outside,
+            "profile.json",
+            allowlisted_roots=(allowed,),
+        )
+
+    with pytest.raises(SourceBoundaryError, match="relative"):
+        read_source_file(outside, "../outside/profile.json")
+
+
+def test_reader_detects_source_changed_during_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "vrcpet"
+    root.mkdir()
+    path = root / "profile.json"
+    path.write_text('{"name":"sui"}', encoding="utf-8")
+    original_read_bytes = Path.read_bytes
+
+    def changing_read_bytes(self: Path) -> bytes:
+        value = original_read_bytes(self)
+        if self == path:
+            self.write_bytes(value + b" ")
+        return value
+
+    monkeypatch.setattr(Path, "read_bytes", changing_read_bytes)
+    with pytest.raises(UnstableSourceError, match="changed while reading"):
+        read_source_file(root, "profile.json")
+
+
+def test_discovery_is_limited_to_observed_vrcpet_inputs(tmp_path: Path) -> None:
+    root = tmp_path / "vrcpet"
+    logs = root / "logs"
+    logs.mkdir(parents=True)
+    (logs / "2026-08-12.jsonl").write_text("{}\n", encoding="utf-8")
+    (root / "pet.log").write_text("event\n", encoding="utf-8")
+    (root / "profile.json").write_text("{}", encoding="utf-8")
+    (root / "heard_nouns.json").write_text("{}", encoding="utf-8")
+    (root / "secret.txt").write_text("must not be discovered", encoding="utf-8")
+
+    assert discover_source_paths(root) == (
+        "heard_nouns.json",
+        "logs/2026-08-12.jsonl",
+        "pet.log",
+        "profile.json",
+    )
+
+
+def test_normalization_is_content_addressed_and_sanitizes_absolute_path(tmp_path: Path) -> None:
+    raw = b'{"text":"same"}\n'
+    first = normalize_source(
+        _source("logs/a.jsonl", raw),
+        parse_observation("logs/a.jsonl", raw),
+    )
+    renamed = normalize_source(
+        _source("logs/renamed.jsonl", raw),
+        parse_observation("logs/renamed.jsonl", raw),
+    )
+    changed = normalize_source(
+        _source("logs/a.jsonl", b'{"text":"changed"}\n'),
+        parse_observation("logs/a.jsonl", b'{"text":"changed"}\n'),
+    )
+
+    assert first.source_object.id == renamed.source_object.id
+    assert first.source_hash == renamed.source_hash
+    assert first.source_object.id != changed.source_object.id
+    assert first.source_object.object_uri.startswith("private://vrcpet/conversation/")
+    manifest_text = json.dumps(first.manifest, ensure_ascii=False)
+    assert str(tmp_path) not in manifest_text
+    assert first.manifest["metadata"]["source_relative_path"] == "logs/a.jsonl"
+
+
+def test_duplicate_ingest_and_pipeline_version_are_idempotent() -> None:
+    raw = b'{"text":"same"}\n'
+    observation = normalize_source(
+        _source("logs/a.jsonl", raw),
+        parse_observation("logs/a.jsonl", raw),
+    )
+    duplicate = normalize_source(
+        _source("logs/b.jsonl", raw),
+        parse_observation("logs/b.jsonl", raw),
+    )
+
+    assert deduplicate_observations((observation, duplicate)) == (observation,)
+    run = build_ingestion_run(
+        observation,
+        pipeline_version="human-memory-v2:vrcpet-1",
+        at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+    )
+    assert run.idempotency_key == (
+        f"{observation.source_hash}:human-memory-v2:vrcpet-1"
+    )
+
+
+def test_state_snapshot_retains_exact_bytes_and_diff_is_explicit() -> None:
+    profile_raw = b'{"favorite":"blue","mood":"curious"}'
+    profile = normalize_source(
+        _source("profile.json", profile_raw),
+        parse_observation("profile.json", profile_raw),
+    )
+    snapshot = build_state_snapshot(profile, captured_on=date(2026, 8, 12))
+
+    assert snapshot.raw_bytes == profile_raw
+    assert snapshot.object_uri.startswith("private://vrcpet/snapshots/2026-08-12/profile/")
+    profile_delta = diff_profile(
+        {"favorite": "blue", "mood": "calm", "old": True},
+        {"favorite": "blue", "mood": "curious", "new": 1},
+    )
+    assert profile_delta.added == {"new": 1}
+    assert profile_delta.removed == {"old": True}
+    assert profile_delta.changed == {"mood": ("calm", "curious")}
+
+    vocabulary_delta = diff_vocabulary_counts(
+        {"旅行": 2, "GPU": 4, "old": 1},
+        {"旅行": 5, "GPU": 3, "京都": 1},
+    )
+    assert vocabulary_delta.new == {"京都": 1}
+    assert vocabulary_delta.increased == {"旅行": (2, 5)}
+    assert vocabulary_delta.decreased == {"GPU": (4, 3)}
+    assert vocabulary_delta.missing == {"old": 1}
+
+
+def test_observation_associates_with_existing_episode_without_memory_claim_promotion() -> None:
+    primary = SourceObject(
+        kind=SourceKind.AUDIO,
+        object_uri="private://audio/session.flac",
+        sha256="0" * 64,
+        size_bytes=10,
+        recorded_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+        privacy=PrivacyLevel.PRIVATE,
+    )
+    episode = Episode(
+        started_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 8, 12, 1, tzinfo=timezone.utc),
+        source_object_ids=(primary.id,),
+    )
+    raw = b'{"text":"Kyoto"}\n'
+    observation = normalize_source(
+        _source("logs/day.jsonl", raw),
+        parse_observation("logs/day.jsonl", raw),
+    )
+
+    associated = associate_episode(episode, (observation, observation))
+    assert associated.id == episode.id
+    assert associated.source_object_ids == (primary.id, observation.source_object.id)
+    assert not hasattr(normalizer_module, "MemoryClaim")
+
+
+def test_end_to_end_daily_companion_view_is_rebuildable() -> None:
+    conversation_raw = b'{"text":"travel"}\n{"broken":\n{"text":"Kyoto"}\n'
+    profile_raw = b'{"favorite":"blue","mood":"curious"}'
+    vocabulary_raw = '{"旅行":5,"GPU":3,"京都":1}'.encode()
+
+    conversation = normalize_source(
+        _source("logs/2026-08-12.jsonl", conversation_raw),
+        parse_observation("logs/2026-08-12.jsonl", conversation_raw),
+    )
+    profile = normalize_source(
+        _source("profile.json", profile_raw),
+        parse_observation("profile.json", profile_raw),
+    )
+    vocabulary = normalize_source(
+        _source("heard_nouns.json", vocabulary_raw),
+        parse_observation("heard_nouns.json", vocabulary_raw),
+    )
+    snapshots = (
+        build_state_snapshot(profile, captured_on=date(2026, 8, 12)),
+        build_state_snapshot(vocabulary, captured_on=date(2026, 8, 12)),
+    )
+    vocabulary_delta = diff_vocabulary_counts(
+        {"旅行": 2, "GPU": 4, "old": 1},
+        {"旅行": 5, "GPU": 3, "京都": 1},
+    )
+    profile_delta = diff_profile(
+        {"favorite": "blue", "mood": "calm"},
+        {"favorite": "blue", "mood": "curious"},
+    )
+
+    view = build_companion_daily_view(
+        day=date(2026, 8, 12),
+        observations=(conversation, profile, vocabulary),
+        snapshots=snapshots,
+        current_counts={"旅行": 5, "GPU": 3, "京都": 1},
+        vocabulary_diff=vocabulary_delta,
+        profile_diff=profile_delta,
+        pet_utterances=("こんにちは",),
+    )
+    rendered = view.render_markdown(pet_name="すい")
+
+    assert view.conversation_records == 2
+    assert view.parse_issues == 1
+    assert view.snapshots == 2
+    assert "# すいの目から見た2026-08-12" in rendered
+    assert "京都" in rendered
+    assert "mood" in rendered
+    assert "こんにちは" in rendered

--- a/tests/test_vrcpet_adapter.py
+++ b/tests/test_vrcpet_adapter.py
@@ -229,8 +229,9 @@ def test_state_snapshot_retains_exact_bytes_and_diff_is_explicit() -> None:
     assert vocabulary_delta.missing == {"old": 1}
 
 
-def test_observation_associates_with_existing_episode_without_memory_claim_promotion(
-) -> None:
+def test_observation_associates_with_existing_episode_without_memory_claim_promotion() -> (
+    None
+):
     primary = SourceObject(
         kind=SourceKind.AUDIO,
         object_uri="private://audio/session.flac",


### PR DESCRIPTION
## Summary

Implements Issue #27 by adding `adapters/vrcpet` as a read-only private observation boundary for VRCPet/Muchio.

- read-only source discovery/reader with allowlist and stable-read checks
- tolerant JSON/JSONL/`pet.log` parsing with malformed-line isolation
- SHA-256 + deterministic UUID normalization into existing `SourceObject`
- reuse of the existing source-manifest contract without Windows absolute paths
- reuse of `IngestionRun(source_hash + pipeline_version)` idempotency
- immutable profile/vocabulary snapshot candidates and explicit diffs
- Episode association without creating/accepting `MemoryClaim`
- rebuildable `すいの目から見た1日` projection
- observed nested `heard_nouns.json -> words -> <term> -> count` support without making that vendor shape canonical
- fixture tests for malformed/empty/partial/duplicate/path/snapshot/Episode/daily-view boundaries

## Privacy

No real VRCPet private payload is committed. Runtime/private data remains outside the public repository; only synthetic fixtures are in CI.

## Verification target

- `task lint`
- `task test`
- fixture E2E in CI
- private real-data smoke test against the user's existing `profile.json`, `heard_nouns.json`, and `pet.log` without uploading those payloads to GitHub

Closes #27