### PR TITLE
Apply KafLog editorial theme foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+      - run: bun run design:check
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run build

--- a/apps/reader/app/globals.css
+++ b/apps/reader/app/globals.css
@@ -1,14 +1,32 @@
 :root {
-  --bg: #05070a;
-  --surface: rgba(15, 23, 32, 0.78);
-  --surface-hover: rgba(20, 32, 44, 0.96);
-  --border: rgba(137, 224, 255, 0.14);
-  --border-strong: rgba(137, 224, 255, 0.34);
-  --text: #edf5f7;
-  --muted: #96a8b4;
-  --accent: #75e6ff;
-  --accent-soft: #b6f2ff;
-  --font-main: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-canvas: #f5f4ef;
+  --color-paper: #ffffff;
+  --color-paper-soft: #fcfbf8;
+  --color-ink: #1a1c20;
+  --color-ink-muted: #5f6f82;
+  --color-ink-subtle: #6b7280;
+  --color-accent: #0f766e;
+  --color-accent-soft: rgba(15, 118, 110, 0.07);
+  --color-border: rgba(26, 28, 32, 0.12);
+  --color-border-strong: rgba(15, 118, 110, 0.36);
+  --color-diary: #0f766e;
+  --color-novel: #8a5a2f;
+  --color-people-said: #76537a;
+  --color-focus: #0f766e;
+  --color-danger: #9f2d2d;
+
+  --font-body: 'Noto Sans JP', 'Hiragino Sans', 'Yu Gothic', system-ui, sans-serif;
+  --font-heading: 'Noto Sans JP', 'Hiragino Sans', 'Yu Gothic', system-ui, sans-serif;
+  --font-mono: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+
+  --motion-fast: 120ms;
+  --motion-normal: 200ms;
+  --motion-slow: 320ms;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 * {
@@ -17,21 +35,24 @@
   padding: 0;
 }
 
+html {
+  background: var(--color-canvas);
+}
+
 body {
   min-height: 100vh;
-  font-family: var(--font-main);
-  color: var(--text);
-  background:
-    radial-gradient(circle at 20% -10%, rgba(0, 194, 255, 0.16), transparent 34rem),
-    var(--bg);
+  font-family: var(--font-body);
+  color: var(--color-ink);
+  background: var(--color-canvas);
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
 }
 
 h1,
 h2 {
+  font-family: var(--font-heading);
   font-weight: 700;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.025em;
 }
 
 .page {
@@ -40,8 +61,7 @@ h2 {
 }
 
 .wrap {
-  width: 100%;
-  max-width: 920px;
+  width: min(1080px, 100%);
   margin: 0 auto;
 }
 
@@ -56,81 +76,81 @@ h2 {
 
 .eyebrow {
   margin-bottom: 10px;
-  color: var(--accent);
+  color: var(--color-accent);
   font-size: 0.75rem;
   font-weight: 800;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .site-title,
 .day-title {
-  color: var(--text);
-  font-size: clamp(2.1rem, 7vw, 4.4rem);
-  line-height: 1.02;
+  color: var(--color-ink);
+  font-size: clamp(2.1rem, 6vw, 3.6rem);
+  line-height: 1.08;
 }
 
 .site-intro {
-  max-width: 36rem;
+  max-width: 38rem;
   margin-top: 18px;
-  color: var(--muted);
+  color: var(--color-ink-muted);
   font-size: 1rem;
-  line-height: 1.8;
+  line-height: 1.85;
 }
 
 .entries {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
+  gap: 16px;
   list-style: none;
 }
 
 .entry-link {
-  min-height: 240px;
+  min-height: 232px;
   display: flex;
   flex-direction: column;
   padding: 24px;
   color: inherit;
   text-decoration: none;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 18px;
+  background: var(--color-paper);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   transition:
-    background 160ms ease,
-    border-color 160ms ease,
-    transform 160ms ease;
+    background-color var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard);
 }
 
 .entry-link:hover {
-  background: var(--surface-hover);
-  border-color: var(--border-strong);
-  transform: translateY(-2px);
+  background: var(--color-paper-soft);
+  border-color: var(--color-border-strong);
 }
 
 .entry-link:focus-visible,
 .back-link:focus-visible {
-  outline: 3px solid var(--accent);
-  outline-offset: 4px;
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
 }
 
 .entry-date,
 .day-date {
-  color: var(--accent-soft);
-  font-size: 0.82rem;
+  color: var(--color-diary);
+  font-size: 0.8125rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
 }
 
 .entry-title {
   margin-top: 16px;
+  color: var(--color-ink);
   font-size: 1.25rem;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 
 .entry-preview {
   display: -webkit-box;
   margin-top: 12px;
-  color: var(--muted);
-  line-height: 1.7;
+  color: var(--color-ink-muted);
+  line-height: 1.75;
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
@@ -139,30 +159,34 @@ h2 {
 .entry-action {
   margin-top: auto;
   padding-top: 20px;
-  color: var(--accent);
-  font-size: 0.86rem;
+  color: var(--color-accent);
+  font-size: 0.875rem;
   font-weight: 700;
 }
 
 .back-link {
   display: inline-flex;
-  margin-bottom: 48px;
-  color: var(--muted);
+  min-height: 44px;
+  align-items: center;
+  margin-bottom: 40px;
+  color: var(--color-ink-muted);
   text-decoration: none;
+  border-radius: var(--radius-sm);
+  transition: color var(--motion-fast) var(--ease-standard);
 }
 
 .back-link:hover {
-  color: var(--text);
+  color: var(--color-accent);
 }
 
 .day-header {
   padding-bottom: 32px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .day-title {
   max-width: 680px;
-  font-size: clamp(2rem, 6vw, 3.8rem);
+  font-size: clamp(2rem, 5vw, 3rem);
 }
 
 .day-date {
@@ -171,28 +195,30 @@ h2 {
 }
 
 .entry-copy {
-  padding-top: 38px;
+  padding-top: 36px;
 }
 
 .entry-body {
-  color: rgba(237, 245, 247, 0.92);
-  font-size: 1.04rem;
-  line-height: 2;
+  max-width: 46rem;
+  color: var(--color-ink);
+  font-size: 1.0625rem;
+  line-height: 1.95;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .empty-state {
   display: grid;
   gap: 10px;
   padding: 28px;
-  color: var(--muted);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 18px;
+  color: var(--color-ink-muted);
+  background: var(--color-paper);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
 }
 
 .empty-state h1 {
-  color: var(--text);
+  color: var(--color-ink);
   font-size: 1.5rem;
 }
 
@@ -210,12 +236,12 @@ h2 {
   }
 
   .entry-link {
-    min-height: 210px;
+    min-height: 204px;
     padding: 20px;
   }
 
   .back-link {
-    margin-bottom: 36px;
+    margin-bottom: 28px;
   }
 
   .entry-body {
@@ -225,7 +251,8 @@ h2 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .entry-link {
+  .entry-link,
+  .back-link {
     transition: none;
   }
 }

--- a/apps/reader/package.json
+++ b/apps/reader/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint app lib next.config.ts"
+    "lint": "eslint app lib next.config.ts",
+    "design:check": "node scripts/check-design-contract.mjs"
   },
   "dependencies": {
     "next": "^16.1.0",

--- a/apps/reader/scripts/check-design-contract.mjs
+++ b/apps/reader/scripts/check-design-contract.mjs
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const cssPath = resolve(here, '../app/globals.css')
+const css = readFileSync(cssPath, 'utf8')
+
+function fail(message) {
+  console.error(`design-contract: ${message}`)
+  process.exitCode = 1
+}
+
+const forbidden = [
+  ['legacy black canvas', '#05070a'],
+  ['legacy cyan accent', '#75e6ff'],
+  ['radial neon treatment', 'radial-gradient'],
+  ['hover lift transform', 'translateY('],
+]
+
+for (const [name, needle] of forbidden) {
+  if (css.includes(needle)) fail(`${name} is forbidden (${needle})`)
+}
+
+const requiredTokens = [
+  '--color-canvas',
+  '--color-paper',
+  '--color-ink',
+  '--color-ink-muted',
+  '--color-accent',
+  '--color-border',
+  '--color-diary',
+  '--color-novel',
+  '--color-people-said',
+  '--color-focus',
+]
+
+for (const token of requiredTokens) {
+  if (!css.includes(`${token}:`)) fail(`missing required semantic token ${token}`)
+}
+
+if (!css.includes('outline: 3px solid var(--color-focus)')) {
+  fail('author-defined focus indicator must use the canonical 3px focus outline')
+}
+
+if (!css.includes('@media (prefers-reduced-motion: reduce)')) {
+  fail('prefers-reduced-motion contract is missing')
+}
+
+function tokenHex(name) {
+  const match = css.match(new RegExp(`${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*:\\s*(#[0-9a-fA-F]{6})`))
+  if (!match) {
+    fail(`cannot read hex value for ${name}`)
+    return '#000000'
+  }
+  return match[1]
+}
+
+function channelToLinear(value) {
+  const normalized = value / 255
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+function luminance(hex) {
+  const value = hex.slice(1)
+  const r = channelToLinear(Number.parseInt(value.slice(0, 2), 16))
+  const g = channelToLinear(Number.parseInt(value.slice(2, 4), 16))
+  const b = channelToLinear(Number.parseInt(value.slice(4, 6), 16))
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrastRatio(foreground, background) {
+  const a = luminance(foreground)
+  const b = luminance(background)
+  const lighter = Math.max(a, b)
+  const darker = Math.min(a, b)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+const canvas = tokenHex('--color-canvas')
+const paper = tokenHex('--color-paper')
+const textTokens = [
+  '--color-ink',
+  '--color-ink-muted',
+  '--color-accent',
+  '--color-diary',
+  '--color-novel',
+  '--color-people-said',
+]
+
+for (const token of textTokens) {
+  const foreground = tokenHex(token)
+  for (const [surfaceName, background] of [
+    ['canvas', canvas],
+    ['paper', paper],
+  ]) {
+    const ratio = contrastRatio(foreground, background)
+    if (ratio < 4.5) {
+      fail(`${token} contrast on ${surfaceName} is ${ratio.toFixed(2)}:1; expected >= 4.5:1`)
+    }
+  }
+}
+
+if (process.exitCode) process.exit(process.exitCode)
+console.log('design-contract: semantic tokens, legacy-theme ban, focus, motion, and text contrast all pass')


### PR DESCRIPTION
## Summary

Advances #44 without closing it.

This PR applies the #43 Design System to the Reader surfaces that exist today (Home and Diary) and adds a machine-enforced design contract.

### Runtime styling
- migrate from legacy black/cyan tokens to semantic KafLog tokens
- remove radial glow and hover lift
- use warm canvas / paper surfaces and Deep Teal identity
- tighten Japanese reading typography and detail measure
- keep mobile one-column flow and reduced-motion support
- make focus a real 3px outline rather than glow-only styling

### Mechanical checks
- reject legacy `#05070a`, `#75e6ff`, `radial-gradient`, and `translateY(`
- require canonical semantic tokens
- require the canonical focus outline and reduced-motion media query
- compute WCAG relative luminance/contrast from the CSS token values
- require normal-text token pairs used on canvas/paper to remain >= 4.5:1
- run the design contract before reader typecheck/lint/build in CI

## Why #44 stays open

People Said (#36) and Timeline (#40) are not implemented yet, so their styling and the complete visual-regression snapshot matrix cannot truthfully be completed now. This PR establishes the base theme; #44 remains open until those views exist and representative desktop/mobile visual snapshots are fixed in CI.

## Scope verification

- branch is ahead of current main with no divergence
- no data model, privacy, publication, navigation IA, or Social Mirror extraction changes
- no new runtime dependency; package script only

Related: #43, #36, #40, #41, #42