### PR TITLE
Define evidence-backed Social Mirror claim contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
 
       - run: uv sync --only-group dev
       - run: uv run ruff check apps/capture-vrchat/src packages scripts tests infra/systemd
-      - run: uv run ruff format --check apps/capture-vrchat/src packages scripts tests infra/systemd
+      - run: uv run ruff format --check --diff apps/capture-vrchat/src packages scripts tests infra/systemd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
 
       - run: uv sync --only-group dev
       - run: uv run ruff check apps/capture-vrchat/src packages scripts tests infra/systemd
-      - run: uv run ruff format --check --diff apps/capture-vrchat/src packages scripts tests infra/systemd
+      - run: uv run ruff format --check apps/capture-vrchat/src packages scripts tests infra/systemd

--- a/packages/memory-domain/README.md
+++ b/packages/memory-domain/README.md
@@ -3,3 +3,17 @@
 Status: foundation implemented.
 
 Responsibility: canonical entity and provenance invariants. Provider-specific code and application wiring do not belong here. See [Human Memory v2](../../docs/architecture/human-memory-v2.md).
+
+## Social Mirror evidence contract
+
+Social Mirror does not introduce another canonical store. A Social Mirror observation remains a normal `MemoryClaim` with `claim_type="social_mirror"`, canonical `EvidenceRef` provenance, and a typed `SocialMirrorValue`.
+
+Evidence levels are deliberately non-interchangeable:
+
+- `direct_quote`: exact text must occur in a referenced raw `Utterance` whose episode matches the `EvidenceRef`.
+- `paraphrase`: evidence-backed speech content without a claim of verbatim wording.
+- `inferred_impression`: an interpretation only; `is_spoken_fact` is always false.
+
+A quotation mark in a summary, Diary, Novel, or other derived artifact is not sufficient to promote content to `direct_quote`. Unknown speakers remain `speaker_label="unknown"` unless independent identity evidence exists.
+
+`validate_social_mirror_claim()` is the dereferencing evidence gate because JSON Schema can validate shape and provenance presence but cannot inspect external raw utterance text.

--- a/packages/memory-domain/src/vlog_memory_domain/__init__.py
+++ b/packages/memory-domain/src/vlog_memory_domain/__init__.py
@@ -22,6 +22,13 @@ from .models import (
     SourceObject,
     Utterance,
 )
+from .social_mirror import (
+    SOCIAL_MIRROR_CLAIM_TYPE,
+    UNKNOWN_SPEAKER,
+    SocialMirrorEvidenceLevel,
+    SocialMirrorValue,
+    validate_social_mirror_claim,
+)
 
 __all__ = [
     "Artifact",
@@ -37,7 +44,12 @@ __all__ = [
     "Moment",
     "PrivacyLevel",
     "PublicationDecision",
+    "SOCIAL_MIRROR_CLAIM_TYPE",
     "SourceKind",
     "SourceObject",
+    "SocialMirrorEvidenceLevel",
+    "SocialMirrorValue",
+    "UNKNOWN_SPEAKER",
     "Utterance",
+    "validate_social_mirror_claim",
 ]

--- a/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
+++ b/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Mapping
+from uuid import UUID
+
+from .models import MemoryClaim, Utterance
+
+SOCIAL_MIRROR_CLAIM_TYPE = "social_mirror"
+UNKNOWN_SPEAKER = "unknown"
+
+
+class SocialMirrorEvidenceLevel(StrEnum):
+    """How strongly a Social Mirror claim is supported as speech evidence."""
+
+    DIRECT_QUOTE = "direct_quote"
+    PARAPHRASE = "paraphrase"
+    INFERRED_IMPRESSION = "inferred_impression"
+
+
+@dataclass(frozen=True, slots=True)
+class SocialMirrorValue:
+    """Typed value stored inside a canonical ``MemoryClaim``.
+
+    This is a value object, not a separate canonical store. The enclosing
+    ``MemoryClaim`` continues to own time, status, confidence, and EvidenceRef
+    provenance.
+    """
+
+    evidence_level: SocialMirrorEvidenceLevel
+    text: str
+    speaker_label: str
+    speaker_entity_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("social mirror text must not be empty")
+        if not self.speaker_label.strip():
+            raise ValueError("speaker_label must not be empty; use 'unknown' when unknown")
+        if self.speaker_entity_id is not None:
+            try:
+                UUID(self.speaker_entity_id)
+            except (ValueError, TypeError) as exc:
+                raise ValueError("speaker_entity_id must be a UUID string") from exc
+
+    @property
+    def is_verbatim(self) -> bool:
+        return self.evidence_level is SocialMirrorEvidenceLevel.DIRECT_QUOTE
+
+    @property
+    def is_spoken_fact(self) -> bool:
+        """Whether this value represents speech rather than an interpretation."""
+
+        return self.evidence_level in {
+            SocialMirrorEvidenceLevel.DIRECT_QUOTE,
+            SocialMirrorEvidenceLevel.PARAPHRASE,
+        }
+
+
+def validate_social_mirror_claim(
+    claim: MemoryClaim,
+    *,
+    utterances_by_id: Mapping[str, Utterance] | None = None,
+) -> None:
+    """Validate Social Mirror semantics against canonical evidence.
+
+    JSON Schema can validate the shape of a Social Mirror value, but it cannot
+    dereference EvidenceRef objects into raw utterance text. This function is
+    the domain-level evidence gate used before a candidate is treated according
+    to its declared evidence level.
+
+    ``direct_quote`` requires the exact text to occur in a referenced raw
+    ``Utterance`` whose episode matches the EvidenceRef. A quotation mark in a
+    summary, diary, Novel, or other derived artifact therefore cannot promote a
+    claim to ``direct_quote`` without raw utterance evidence.
+    """
+
+    if claim.claim_type != SOCIAL_MIRROR_CLAIM_TYPE:
+        raise ValueError("claim_type must be 'social_mirror'")
+    if not isinstance(claim.value, SocialMirrorValue):
+        raise ValueError("social_mirror claims require a SocialMirrorValue")
+    if not claim.evidence:
+        raise ValueError("social_mirror claims require provenance evidence")
+
+    value = claim.value
+    if value.evidence_level is not SocialMirrorEvidenceLevel.DIRECT_QUOTE:
+        return
+
+    if utterances_by_id is None:
+        raise ValueError("direct_quote validation requires raw utterance evidence")
+
+    referenced_utterance = False
+    for evidence_ref in claim.evidence:
+        if evidence_ref.utterance_id is None:
+            continue
+        utterance = utterances_by_id.get(evidence_ref.utterance_id)
+        if utterance is None:
+            continue
+        if utterance.episode_id != evidence_ref.episode_id:
+            continue
+        referenced_utterance = True
+        if value.text in utterance.text:
+            return
+
+    if not referenced_utterance:
+        raise ValueError("direct_quote requires a referenced raw utterance")
+    raise ValueError("direct_quote text must appear verbatim in referenced raw evidence")

--- a/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
+++ b/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
@@ -37,7 +37,9 @@ class SocialMirrorValue:
         if not self.text.strip():
             raise ValueError("social mirror text must not be empty")
         if not self.speaker_label.strip():
-            raise ValueError("speaker_label must not be empty; use 'unknown' when unknown")
+            raise ValueError(
+                "speaker_label must not be empty; use 'unknown' when unknown"
+            )
         if self.speaker_entity_id is not None:
             try:
                 UUID(self.speaker_entity_id)

--- a/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
+++ b/packages/memory-domain/src/vlog_memory_domain/social_mirror.py
@@ -107,4 +107,6 @@ def validate_social_mirror_claim(
 
     if not referenced_utterance:
         raise ValueError("direct_quote requires a referenced raw utterance")
-    raise ValueError("direct_quote text must appear verbatim in referenced raw evidence")
+    raise ValueError(
+        "direct_quote text must appear verbatim in referenced raw evidence"
+    )

--- a/schemas/memory-claim.schema.json
+++ b/schemas/memory-claim.schema.json
@@ -35,6 +35,18 @@
     {
       "if": {"properties": {"status": {"const": "accepted"}}, "required": ["status"]},
       "then": {"properties": {"evidence": {"minItems": 1}}}
+    },
+    {
+      "if": {
+        "properties": {"claim_type": {"const": "social_mirror"}},
+        "required": ["claim_type"]
+      },
+      "then": {
+        "properties": {
+          "value": {"$ref": "#/$defs/socialMirrorValue"},
+          "evidence": {"minItems": 1}
+        }
+      }
     }
   ],
   "$defs": {
@@ -48,6 +60,20 @@
         "utterance_id": {"type": ["string", "null"], "format": "uuid"},
         "start_ms": {"type": ["integer", "null"], "minimum": 0},
         "end_ms": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "socialMirrorValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_level", "text", "speaker_label"],
+      "properties": {
+        "evidence_level": {
+          "type": "string",
+          "enum": ["direct_quote", "paraphrase", "inferred_impression"]
+        },
+        "text": {"type": "string", "minLength": 1},
+        "speaker_label": {"type": "string", "minLength": 1},
+        "speaker_entity_id": {"type": ["string", "null"], "format": "uuid"}
       }
     }
   }

--- a/tests/test_social_mirror_contract.py
+++ b/tests/test_social_mirror_contract.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "packages" / "memory-domain" / "src"))
+
+from vlog_memory_domain import (  # noqa: E402
+    EvidenceRef,
+    MemoryClaim,
+    SocialMirrorEvidenceLevel,
+    SocialMirrorValue,
+    Utterance,
+    validate_social_mirror_claim,
+)
+
+NOW = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)
+
+
+def make_evidence(*, episode_id: str, utterance_id: str | None = None) -> EvidenceRef:
+    return EvidenceRef(
+        source_object_id=str(uuid4()),
+        episode_id=episode_id,
+        utterance_id=utterance_id,
+    )
+
+
+def make_claim(value: SocialMirrorValue, evidence: tuple[EvidenceRef, ...]) -> MemoryClaim:
+    return MemoryClaim(
+        claim_type="social_mirror",
+        subject_entity_id=str(uuid4()),
+        value=value,
+        valid_from=NOW,
+        evidence=evidence,
+    )
+
+
+def test_direct_quote_requires_verbatim_raw_utterance_match() -> None:
+    episode_id = str(uuid4())
+    utterance_id = str(uuid4())
+    evidence = make_evidence(episode_id=episode_id, utterance_id=utterance_id)
+    claim = make_claim(
+        SocialMirrorValue(
+            evidence_level=SocialMirrorEvidenceLevel.DIRECT_QUOTE,
+            text="研究しすぎ",
+            speaker_label="friend-a",
+        ),
+        (evidence,),
+    )
+    utterance = Utterance(
+        id=utterance_id,
+        episode_id=episode_id,
+        started_at=NOW,
+        ended_at=NOW + timedelta(seconds=2),
+        text="いや、研究しすぎでしょ",
+    )
+
+    validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
+
+
+def test_summary_quote_cannot_promote_without_raw_utterance_evidence() -> None:
+    episode_id = str(uuid4())
+    claim = make_claim(
+        SocialMirrorValue(
+            evidence_level=SocialMirrorEvidenceLevel.DIRECT_QUOTE,
+            text="魔王が来た",
+            speaker_label="unknown",
+        ),
+        (make_evidence(episode_id=episode_id),),
+    )
+
+    with pytest.raises(ValueError, match="referenced raw utterance"):
+        validate_social_mirror_claim(claim, utterances_by_id={})
+
+
+def test_direct_quote_rejects_text_that_is_not_verbatim() -> None:
+    episode_id = str(uuid4())
+    utterance_id = str(uuid4())
+    evidence = make_evidence(episode_id=episode_id, utterance_id=utterance_id)
+    claim = make_claim(
+        SocialMirrorValue(
+            evidence_level=SocialMirrorEvidenceLevel.DIRECT_QUOTE,
+            text="とても詳しい",
+            speaker_label="friend-b",
+        ),
+        (evidence,),
+    )
+    utterance = Utterance(
+        id=utterance_id,
+        episode_id=episode_id,
+        started_at=NOW,
+        ended_at=NOW + timedelta(seconds=1),
+        text="詳しすぎる",
+    )
+
+    with pytest.raises(ValueError, match="appear verbatim"):
+        validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
+
+
+def test_paraphrase_is_evidence_backed_but_not_verbatim() -> None:
+    episode_id = str(uuid4())
+    value = SocialMirrorValue(
+        evidence_level=SocialMirrorEvidenceLevel.PARAPHRASE,
+        text="かなり詳しい人だと言われた",
+        speaker_label="friend-c",
+    )
+    claim = make_claim(value, (make_evidence(episode_id=episode_id),))
+
+    validate_social_mirror_claim(claim)
+
+    assert value.is_spoken_fact is True
+    assert value.is_verbatim is False
+
+
+def test_inferred_impression_is_never_a_spoken_fact() -> None:
+    episode_id = str(uuid4())
+    value = SocialMirrorValue(
+        evidence_level=SocialMirrorEvidenceLevel.INFERRED_IMPRESSION,
+        text="相手は圧倒されたように見えた",
+        speaker_label="unknown",
+    )
+    claim = make_claim(value, (make_evidence(episode_id=episode_id),))
+
+    validate_social_mirror_claim(claim)
+
+    assert value.is_spoken_fact is False
+    assert value.is_verbatim is False
+
+
+def test_unknown_speaker_remains_unknown_without_identity_guessing() -> None:
+    value = SocialMirrorValue(
+        evidence_level=SocialMirrorEvidenceLevel.PARAPHRASE,
+        text="詳しすぎると言われた",
+        speaker_label="unknown",
+    )
+
+    assert value.speaker_label == "unknown"
+    assert value.speaker_entity_id is None
+
+
+def test_social_mirror_schema_fixes_evidence_levels_and_required_metadata() -> None:
+    schema = json.loads((REPO_ROOT / "schemas" / "memory-claim.schema.json").read_text())
+    value_schema = schema["$defs"]["socialMirrorValue"]
+
+    assert set(value_schema["required"]) == {"evidence_level", "text", "speaker_label"}
+    assert value_schema["properties"]["evidence_level"]["enum"] == [
+        "direct_quote",
+        "paraphrase",
+        "inferred_impression",
+    ]
+
+    social_mirror_rule = schema["allOf"][1]
+    assert social_mirror_rule["if"]["properties"]["claim_type"]["const"] == "social_mirror"
+    assert social_mirror_rule["then"]["properties"]["evidence"]["minItems"] == 1

--- a/tests/test_social_mirror_contract.py
+++ b/tests/test_social_mirror_contract.py
@@ -23,7 +23,9 @@ from vlog_memory_domain import (  # noqa: E402
 NOW = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)
 
 
-def make_evidence(*, episode_id: str, utterance_id: str | None = None) -> EvidenceRef:
+def make_evidence(
+    *, episode_id: str, utterance_id: str | None = None
+) -> EvidenceRef:
     return EvidenceRef(
         source_object_id=str(uuid4()),
         episode_id=episode_id,
@@ -31,7 +33,9 @@ def make_evidence(*, episode_id: str, utterance_id: str | None = None) -> Eviden
     )
 
 
-def make_claim(value: SocialMirrorValue, evidence: tuple[EvidenceRef, ...]) -> MemoryClaim:
+def make_claim(
+    value: SocialMirrorValue, evidence: tuple[EvidenceRef, ...]
+) -> MemoryClaim:
     return MemoryClaim(
         claim_type="social_mirror",
         subject_entity_id=str(uuid4()),
@@ -61,7 +65,9 @@ def test_direct_quote_requires_verbatim_raw_utterance_match() -> None:
         text="いや、研究しすぎでしょ",
     )
 
-    validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
+    validate_social_mirror_claim(
+        claim, utterances_by_id={utterance_id: utterance}
+    )
 
 
 def test_summary_quote_cannot_promote_without_raw_utterance_evidence() -> None:
@@ -100,7 +106,9 @@ def test_direct_quote_rejects_text_that_is_not_verbatim() -> None:
     )
 
     with pytest.raises(ValueError, match="appear verbatim"):
-        validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
+        validate_social_mirror_claim(
+            claim, utterances_by_id={utterance_id: utterance}
+        )
 
 
 def test_paraphrase_is_evidence_backed_but_not_verbatim() -> None:
@@ -145,10 +153,16 @@ def test_unknown_speaker_remains_unknown_without_identity_guessing() -> None:
 
 
 def test_social_mirror_schema_fixes_evidence_levels_and_required_metadata() -> None:
-    schema = json.loads((REPO_ROOT / "schemas" / "memory-claim.schema.json").read_text())
+    schema = json.loads(
+        (REPO_ROOT / "schemas" / "memory-claim.schema.json").read_text()
+    )
     value_schema = schema["$defs"]["socialMirrorValue"]
 
-    assert set(value_schema["required"]) == {"evidence_level", "text", "speaker_label"}
+    assert set(value_schema["required"]) == {
+        "evidence_level",
+        "text",
+        "speaker_label",
+    }
     assert value_schema["properties"]["evidence_level"]["enum"] == [
         "direct_quote",
         "paraphrase",
@@ -156,5 +170,8 @@ def test_social_mirror_schema_fixes_evidence_levels_and_required_metadata() -> N
     ]
 
     social_mirror_rule = schema["allOf"][1]
-    assert social_mirror_rule["if"]["properties"]["claim_type"]["const"] == "social_mirror"
+    assert (
+        social_mirror_rule["if"]["properties"]["claim_type"]["const"]
+        == "social_mirror"
+    )
     assert social_mirror_rule["then"]["properties"]["evidence"]["minItems"] == 1

--- a/tests/test_social_mirror_contract.py
+++ b/tests/test_social_mirror_contract.py
@@ -23,9 +23,7 @@ from vlog_memory_domain import (  # noqa: E402
 NOW = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)
 
 
-def make_evidence(
-    *, episode_id: str, utterance_id: str | None = None
-) -> EvidenceRef:
+def make_evidence(*, episode_id: str, utterance_id: str | None = None) -> EvidenceRef:
     return EvidenceRef(
         source_object_id=str(uuid4()),
         episode_id=episode_id,
@@ -65,9 +63,7 @@ def test_direct_quote_requires_verbatim_raw_utterance_match() -> None:
         text="いや、研究しすぎでしょ",
     )
 
-    validate_social_mirror_claim(
-        claim, utterances_by_id={utterance_id: utterance}
-    )
+    validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
 
 
 def test_summary_quote_cannot_promote_without_raw_utterance_evidence() -> None:
@@ -106,9 +102,7 @@ def test_direct_quote_rejects_text_that_is_not_verbatim() -> None:
     )
 
     with pytest.raises(ValueError, match="appear verbatim"):
-        validate_social_mirror_claim(
-            claim, utterances_by_id={utterance_id: utterance}
-        )
+        validate_social_mirror_claim(claim, utterances_by_id={utterance_id: utterance})
 
 
 def test_paraphrase_is_evidence_backed_but_not_verbatim() -> None:
@@ -171,7 +165,6 @@ def test_social_mirror_schema_fixes_evidence_levels_and_required_metadata() -> N
 
     social_mirror_rule = schema["allOf"][1]
     assert (
-        social_mirror_rule["if"]["properties"]["claim_type"]["const"]
-        == "social_mirror"
+        social_mirror_rule["if"]["properties"]["claim_type"]["const"] == "social_mirror"
     )
     assert social_mirror_rule["then"]["properties"]["evidence"]["minItems"] == 1


### PR DESCRIPTION
## Summary

Closes #33.

Implements Social Mirror as a typed value inside the existing Human Memory v2 `MemoryClaim`; no new canonical store is introduced.

### Domain contract
- `direct_quote`
- `paraphrase`
- `inferred_impression`
- explicit `text`, `speaker_label`, optional `speaker_entity_id`
- `UNKNOWN_SPEAKER = "unknown"`
- `is_verbatim` and `is_spoken_fact` semantics

### Evidence gate
`validate_social_mirror_claim()` dereferences canonical `EvidenceRef` objects into raw `Utterance` records:

- every Social Mirror claim requires provenance evidence
- `direct_quote` requires a referenced raw utterance
- the claimed quote must appear verbatim in that utterance
- a quote-like string in a summary, Diary, Novel, or other derived artifact cannot promote itself to `direct_quote`
- paraphrase remains evidence-backed without claiming verbatim wording
- inferred impression is always `is_spoken_fact == false`

### Schema
`memory-claim.schema.json` conditionally requires the Social Mirror value shape and at least one EvidenceRef when `claim_type == "social_mirror"`.

### Tests
Adds fixtures for:
- valid verbatim quote
- summary/derived quote without raw utterance rejection
- non-verbatim quote rejection
- paraphrase semantics
- inferred impression not treated as spoken fact
- unknown speaker preservation
- schema enum/required metadata contract

## Branch state

The branch was created from main before the independent #46 Reader-theme squash merge, so it is currently one commit behind main. The touched files are disjoint from #46; CI on the pull-request merge ref is the authority before merge.