### PR TITLE
Add Social Mirror privacy and publication gate

### DIFF
--- a/packages/privacy/README.md
+++ b/packages/privacy/README.md
@@ -1,5 +1,22 @@
 # privacy
 
-Status: reserved.
+Status: foundation implemented for Social Mirror publication.
 
 Responsibility: redaction, pseudonymization, retention, and publication gates. Provider-specific code and application wiring do not belong here. See [Human Memory v2](../../docs/architecture/human-memory-v2.md).
+
+## Social Mirror publication boundary
+
+Social Mirror claims are private by default. Storing an evidence-backed claim does not grant publication approval.
+
+The publication decision records two independent dimensions:
+
+- `publish_text`: whether the reviewed quote/paraphrase/inference text may enter the public projection.
+- `publish_speaker_identity`: whether the stored speaker label may accompany that text publicly.
+
+Both default to `false`. A public projection is not produced unless `publish_text` is explicitly true.
+
+The projection function accepts an already-canonical `MemoryClaim` plus its publication decision. It does **not** accept raw transcript text, source excerpts, storage clients, or entity lookup services. Public projection records therefore contain only the claim ID, publication-decision ID, evidence level, approved text, optional approved speaker label, and publication time.
+
+Unknown speakers remain `unknown`; this layer never resolves an unknown speaker or an internal entity UUID into a guessed public identity.
+
+Only accepted canonical Social Mirror claims may be projected. The publication decision retains `claim_id`, so every public projection can be traced back to the reviewed claim without exposing its raw evidence.

--- a/packages/privacy/src/vlog_privacy/__init__.py
+++ b/packages/privacy/src/vlog_privacy/__init__.py
@@ -1,0 +1,13 @@
+"""Privacy and publication policy for Human Memory v2 projections."""
+
+from .social_mirror import (
+    SocialMirrorPublicationDecision,
+    SocialMirrorPublicProjection,
+    project_social_mirror_claim,
+)
+
+__all__ = [
+    "SocialMirrorPublicationDecision",
+    "SocialMirrorPublicProjection",
+    "project_social_mirror_claim",
+]

--- a/packages/privacy/src/vlog_privacy/social_mirror.py
+++ b/packages/privacy/src/vlog_privacy/social_mirror.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from vlog_memory_domain import (
+    SOCIAL_MIRROR_CLAIM_TYPE,
+    MemoryClaim,
+    MemoryStatus,
+    SocialMirrorEvidenceLevel,
+    SocialMirrorValue,
+)
+
+
+def _new_id() -> str:
+    return str(uuid4())
+
+
+def _validate_id(value: str, field_name: str) -> None:
+    try:
+        UUID(value)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"{field_name} must be a UUID string") from exc
+
+
+def _validate_aware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+@dataclass(frozen=True, slots=True)
+class SocialMirrorPublicationDecision:
+    """Explicit publication choices for one canonical Social Mirror claim.
+
+    Both publication dimensions default to false. This keeps stored observations
+    private until a deliberate decision is recorded, while allowing quote text
+    and speaker identity to be approved independently.
+    """
+
+    claim_id: str
+    decided_at: datetime
+    decided_by: str
+    rationale: str
+    publish_text: bool = False
+    publish_speaker_identity: bool = False
+    id: str = field(default_factory=_new_id)
+
+    def __post_init__(self) -> None:
+        _validate_id(self.id, "id")
+        _validate_id(self.claim_id, "claim_id")
+        _validate_aware(self.decided_at, "decided_at")
+        if not self.decided_by.strip():
+            raise ValueError("decided_by must not be empty")
+        if not self.rationale.strip():
+            raise ValueError("publication decisions require an explicit rationale")
+
+    @property
+    def is_private(self) -> bool:
+        return not self.publish_text and not self.publish_speaker_identity
+
+
+@dataclass(frozen=True, slots=True)
+class SocialMirrorPublicProjection:
+    """Rebuildable public view with no raw EvidenceRef or transcript content."""
+
+    claim_id: str
+    publication_decision_id: str
+    evidence_level: SocialMirrorEvidenceLevel
+    text: str
+    speaker_label: str | None
+    published_at: datetime
+
+
+def project_social_mirror_claim(
+    claim: MemoryClaim,
+    decision: SocialMirrorPublicationDecision,
+) -> SocialMirrorPublicProjection | None:
+    """Apply publication policy without reading private raw evidence.
+
+    The function consumes only an already-canonical claim and its explicit
+    publication decision. It never accepts transcript text, source excerpts, or
+    entity lookup services, which prevents the public projection step from
+    expanding an unknown speaker into a guessed identity.
+    """
+
+    if claim.id != decision.claim_id:
+        raise ValueError("publication decision must reference the projected claim")
+    if claim.claim_type != SOCIAL_MIRROR_CLAIM_TYPE:
+        raise ValueError("claim_type must be 'social_mirror'")
+    if not isinstance(claim.value, SocialMirrorValue):
+        raise ValueError("social_mirror claims require a SocialMirrorValue")
+    if claim.status is not MemoryStatus.ACCEPTED:
+        raise ValueError("only accepted Social Mirror claims may be published")
+
+    if not decision.publish_text:
+        return None
+
+    speaker_label = None
+    if decision.publish_speaker_identity:
+        speaker_label = claim.value.speaker_label
+
+    return SocialMirrorPublicProjection(
+        claim_id=claim.id,
+        publication_decision_id=decision.id,
+        evidence_level=claim.value.evidence_level,
+        text=claim.value.text,
+        speaker_label=speaker_label,
+        published_at=decision.decided_at,
+    )

--- a/schemas/social-mirror-public-projection.schema.json
+++ b/schemas/social-mirror-public-projection.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/vlog/schemas/social-mirror-public-projection.schema.json",
+  "title": "Social Mirror Public Projection",
+  "description": "Rebuildable public projection. Raw transcript text, source excerpts, EvidenceRef objects, and internal speaker entity IDs are intentionally excluded.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "claim_id",
+    "publication_decision_id",
+    "evidence_level",
+    "text",
+    "speaker_label",
+    "published_at"
+  ],
+  "properties": {
+    "claim_id": {"type": "string", "format": "uuid"},
+    "publication_decision_id": {"type": "string", "format": "uuid"},
+    "evidence_level": {
+      "type": "string",
+      "enum": ["direct_quote", "paraphrase", "inferred_impression"]
+    },
+    "text": {"type": "string", "minLength": 1},
+    "speaker_label": {"type": ["string", "null"]},
+    "published_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/tests/test_social_mirror_privacy.py
+++ b/tests/test_social_mirror_privacy.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "packages" / "memory-domain" / "src"))
+sys.path.insert(0, str(REPO_ROOT / "packages" / "privacy" / "src"))
+
+from vlog_memory_domain import (  # noqa: E402
+    EvidenceRef,
+    MemoryClaim,
+    MemoryStatus,
+    SocialMirrorEvidenceLevel,
+    SocialMirrorValue,
+)
+from vlog_privacy import (  # noqa: E402
+    SocialMirrorPublicationDecision,
+    project_social_mirror_claim,
+)
+
+NOW = datetime(2026, 8, 13, 10, 30, tzinfo=timezone.utc)
+
+
+def make_claim(
+    *,
+    speaker_label: str = "friend-a",
+    speaker_entity_id: str | None = None,
+    status: MemoryStatus = MemoryStatus.ACCEPTED,
+) -> MemoryClaim:
+    evidence = EvidenceRef(
+        source_object_id=str(uuid4()),
+        episode_id=str(uuid4()),
+        utterance_id=str(uuid4()),
+    )
+    return MemoryClaim(
+        claim_type="social_mirror",
+        subject_entity_id=str(uuid4()),
+        value=SocialMirrorValue(
+            evidence_level=SocialMirrorEvidenceLevel.PARAPHRASE,
+            text="詳しすぎると言われた",
+            speaker_label=speaker_label,
+            speaker_entity_id=speaker_entity_id,
+        ),
+        valid_from=NOW,
+        evidence=(evidence,),
+        status=status,
+        confidence=0.9,
+    )
+
+
+def make_decision(
+    claim: MemoryClaim,
+    *,
+    publish_text: bool = False,
+    publish_speaker_identity: bool = False,
+) -> SocialMirrorPublicationDecision:
+    return SocialMirrorPublicationDecision(
+        claim_id=claim.id,
+        decided_at=NOW,
+        decided_by="owner",
+        rationale="explicit publication review",
+        publish_text=publish_text,
+        publish_speaker_identity=publish_speaker_identity,
+    )
+
+
+def test_social_mirror_publication_is_private_by_default() -> None:
+    claim = make_claim()
+    decision = make_decision(claim)
+
+    assert decision.is_private is True
+    assert decision.publish_text is False
+    assert decision.publish_speaker_identity is False
+    assert project_social_mirror_claim(claim, decision) is None
+
+
+def test_text_can_be_published_without_speaker_identity() -> None:
+    claim = make_claim(
+        speaker_label="friend-a",
+        speaker_entity_id=str(uuid4()),
+    )
+    decision = make_decision(claim, publish_text=True)
+
+    projection = project_social_mirror_claim(claim, decision)
+
+    assert projection is not None
+    assert projection.text == "詳しすぎると言われた"
+    assert projection.speaker_label is None
+
+
+def test_speaker_identity_requires_its_own_explicit_decision() -> None:
+    claim = make_claim(
+        speaker_label="friend-a",
+        speaker_entity_id=str(uuid4()),
+    )
+    decision = make_decision(
+        claim,
+        publish_text=True,
+        publish_speaker_identity=True,
+    )
+
+    projection = project_social_mirror_claim(claim, decision)
+
+    assert projection is not None
+    assert projection.speaker_label == "friend-a"
+
+
+def test_unknown_speaker_is_not_resolved_or_guessed() -> None:
+    claim = make_claim(speaker_label="unknown")
+    decision = make_decision(
+        claim,
+        publish_text=True,
+        publish_speaker_identity=True,
+    )
+
+    projection = project_social_mirror_claim(claim, decision)
+
+    assert projection is not None
+    assert projection.speaker_label == "unknown"
+
+
+def test_public_projection_excludes_raw_evidence_and_internal_speaker_id() -> None:
+    claim = make_claim(
+        speaker_label="friend-a",
+        speaker_entity_id=str(uuid4()),
+    )
+    decision = make_decision(
+        claim,
+        publish_text=True,
+        publish_speaker_identity=True,
+    )
+
+    projection = project_social_mirror_claim(claim, decision)
+    assert projection is not None
+    payload = asdict(projection)
+
+    assert set(payload) == {
+        "claim_id",
+        "publication_decision_id",
+        "evidence_level",
+        "text",
+        "speaker_label",
+        "published_at",
+    }
+    assert "evidence" not in payload
+    assert "source_excerpt" not in payload
+    assert "transcript" not in payload
+    assert "speaker_entity_id" not in payload
+
+
+def test_publication_decision_and_projection_trace_to_original_claim() -> None:
+    claim = make_claim()
+    decision = make_decision(claim, publish_text=True)
+
+    projection = project_social_mirror_claim(claim, decision)
+
+    assert projection is not None
+    assert decision.claim_id == claim.id
+    assert projection.claim_id == claim.id
+    assert projection.publication_decision_id == decision.id
+
+
+def test_mismatched_publication_decision_is_rejected() -> None:
+    claim = make_claim()
+    other_claim = make_claim()
+    decision = make_decision(other_claim, publish_text=True)
+
+    with pytest.raises(ValueError, match="reference the projected claim"):
+        project_social_mirror_claim(claim, decision)
+
+
+def test_candidate_claim_cannot_be_published() -> None:
+    claim = make_claim(status=MemoryStatus.CANDIDATE)
+    decision = make_decision(claim, publish_text=True)
+
+    with pytest.raises(ValueError, match="only accepted"):
+        project_social_mirror_claim(claim, decision)
+
+
+def test_public_projection_schema_has_no_raw_source_fields() -> None:
+    schema = json.loads(
+        (
+            REPO_ROOT / "schemas" / "social-mirror-public-projection.schema.json"
+        ).read_text()
+    )
+    properties = set(schema["properties"])
+
+    assert schema["additionalProperties"] is False
+    assert properties == {
+        "claim_id",
+        "publication_decision_id",
+        "evidence_level",
+        "text",
+        "speaker_label",
+        "published_at",
+    }
+    assert properties.isdisjoint(
+        {
+            "evidence",
+            "source_object_id",
+            "source_excerpt",
+            "transcript",
+            "speaker_entity_id",
+        }
+    )


### PR DESCRIPTION
## Summary

Closes #35.

Builds the first executable `packages/privacy` boundary for Social Mirror publication without adding a second canonical store.

### Private by default
- `SocialMirrorPublicationDecision.publish_text = false`
- `publish_speaker_identity = false`
- no public projection exists until text publication is explicitly approved

### Separate publication dimensions
Quote/paraphrase/inference text and speaker identity are independent review choices. Speaker labels are omitted unless identity publication is explicitly approved.

### Public projection minimization
The projection type/schema contains only:
- canonical claim ID
- publication decision ID
- evidence level
- approved text
- optional approved speaker label
- publication timestamp

It intentionally contains no `EvidenceRef`, raw transcript/source excerpt, source-object ID, or internal `speaker_entity_id`.

### No identity guessing
The projection function accepts no entity resolver or raw source lookup. `unknown` remains `unknown`; internal entity UUIDs cannot be expanded into a public identity by this layer.

### Traceability and state gate
- publication decision references the original `claim_id`
- projection records both claim and decision IDs
- only `accepted` Social Mirror claims may be projected

### CI contract
Adds tests for private defaults, separate text/identity publication, unknown speaker preservation, raw-evidence field exclusion, claim/decision traceability, mismatched decisions, candidate rejection, and the public projection JSON Schema boundary. These tests run in the existing Test and Security Audit workflow.

## Scope
No Reader UI, backfill extraction, or provider-specific persistence changes.