### PR TITLE
Add public-only People Said Reader view

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run design:check
+      - run: bun run test
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run build

--- a/apps/reader/README.md
+++ b/apps/reader/README.md
@@ -8,6 +8,14 @@ The Reader is a Next.js application under `apps/reader/`. It presents current di
 
 Implementation changes should consume semantic tokens rather than introducing component-local brand colors or restoring the previous black/cyan neon treatment.
 
+## Public projection inputs
+
+The Reader consumes public projections only. `People Said / 人から言われたこと` reads `data/public/social_mirror.jsonl` when that projection exists.
+
+Each row follows `schemas/social-mirror-public-projection.schema.json`. Reader parsing rejects records that carry raw/private source fields such as `EvidenceRef`, source-object IDs, transcript text, source excerpts, or internal speaker entity IDs. Missing projection files produce an empty state rather than falling back to canonical/private data.
+
+`context` and `reaction` are optional public-projection annotations. Their absence is displayed as absence; the Reader does not infer either value from a quote, Diary, or raw source.
+
 ## Development
 
 Use repository tasks so dependency installation, type checking, linting, and production build remain aligned:
@@ -17,6 +25,8 @@ task web:dev
 task web:build
 task web:start
 ```
+
+Reader contract tests run with Bun and are included in CI.
 
 ## Boundaries
 

--- a/apps/reader/app/people-said/page.module.css
+++ b/apps/reader/app/people-said/page.module.css
@@ -1,0 +1,120 @@
+.header {
+  margin-bottom: 32px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.list {
+  display: grid;
+  gap: 18px;
+  list-style: none;
+}
+
+.card {
+  padding: 24px;
+  background: var(--color-paper);
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-people-said);
+  border-radius: var(--radius-lg);
+}
+
+.card[data-evidence-level='inferred_impression'] {
+  border-left-style: dashed;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  color: var(--color-ink-muted);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 2px 9px;
+  color: var(--color-people-said);
+  background: var(--color-paper-soft);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.context {
+  margin-top: 18px;
+  color: var(--color-ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.quote,
+.text {
+  margin-top: 18px;
+  color: var(--color-ink);
+  font-size: 1.125rem;
+  line-height: 1.9;
+  overflow-wrap: anywhere;
+}
+
+.quote {
+  padding-left: 18px;
+  border-left: 2px solid var(--color-people-said);
+}
+
+.text {
+  white-space: pre-wrap;
+}
+
+.speaker {
+  margin-top: 18px;
+  color: var(--color-ink-muted);
+  font-size: 0.875rem;
+}
+
+.reaction {
+  margin-top: 20px;
+  padding: 16px 18px;
+  background: var(--color-paper-soft);
+  border-radius: var(--radius-md);
+}
+
+.reaction span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-ink-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.reaction p {
+  line-height: 1.75;
+}
+
+.empty h2 {
+  color: var(--color-ink);
+  font-size: 1.25rem;
+}
+
+@media (max-width: 720px) {
+  .header {
+    margin-bottom: 24px;
+    padding-bottom: 24px;
+  }
+
+  .list {
+    gap: 14px;
+  }
+
+  .card {
+    padding: 20px;
+  }
+
+  .quote,
+  .text {
+    font-size: 1rem;
+  }
+}

--- a/apps/reader/app/people-said/page.tsx
+++ b/apps/reader/app/people-said/page.tsx
@@ -7,6 +7,8 @@ import {
   publicSpeakerLabel,
 } from '@/lib/people-said'
 
+import styles from './page.module.css'
+
 export default async function PeopleSaidPage() {
   const entries = await getPeopleSaidEntries()
 
@@ -17,7 +19,7 @@ export default async function PeopleSaidPage() {
           ← KafLogへ戻る
         </Link>
 
-        <header className="people-said-header">
+        <header className={styles.header}>
           <p className="eyebrow">PEOPLE SAID</p>
           <h1 className="day-title">人から言われたこと</h1>
           <p className="site-intro">
@@ -26,12 +28,12 @@ export default async function PeopleSaidPage() {
         </header>
 
         {entries.length === 0 ? (
-          <div className="empty-state people-said-empty">
+          <div className={`empty-state ${styles.empty}`}>
             <h2>まだ公開された言葉はありません。</h2>
             <p>非公開の記録や元の会話ログは、このReaderには表示されません。</p>
           </div>
         ) : (
-          <ol className="people-said-list">
+          <ol className={styles.list}>
             {entries.map(entry => {
               const date = entry.occurredAt.slice(0, 10)
               const label = evidenceLevelLabel(entry.evidenceLevel)
@@ -39,31 +41,32 @@ export default async function PeopleSaidPage() {
               return (
                 <li key={`${entry.id}:${entry.publicationDecisionId}`}>
                   <article
-                    className={`people-said-card people-said-${entry.evidenceLevel}`}
+                    className={styles.card}
+                    data-evidence-level={entry.evidenceLevel}
                   >
-                    <div className="people-said-meta">
+                    <div className={styles.meta}>
                       <time dateTime={entry.occurredAt}>{formatDateOnly(date)}</time>
-                      <span className="evidence-badge">{label}</span>
+                      <span className={styles.badge}>{label}</span>
                     </div>
 
-                    <p className="people-said-context">
+                    <p className={styles.context}>
                       {entry.context ?? '文脈は公開していません'}
                     </p>
 
                     {entry.evidenceLevel === 'direct_quote' ? (
-                      <blockquote className="people-said-quote">
+                      <blockquote className={styles.quote}>
                         <p>「{entry.text}」</p>
                       </blockquote>
                     ) : (
-                      <p className="people-said-text">{entry.text}</p>
+                      <p className={styles.text}>{entry.text}</p>
                     )}
 
-                    <p className="people-said-speaker">
+                    <p className={styles.speaker}>
                       {publicSpeakerLabel(entry.speakerLabel)}
                     </p>
 
                     {entry.reaction ? (
-                      <aside className="people-said-reaction">
+                      <aside className={styles.reaction}>
                         <span>その時の自分</span>
                         <p>{entry.reaction}</p>
                       </aside>

--- a/apps/reader/app/people-said/page.tsx
+++ b/apps/reader/app/people-said/page.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link'
+
+import { formatDateOnly } from '@/lib/entries'
+import {
+  evidenceLevelLabel,
+  getPeopleSaidEntries,
+  publicSpeakerLabel,
+} from '@/lib/people-said'
+
+export default async function PeopleSaidPage() {
+  const entries = await getPeopleSaidEntries()
+
+  return (
+    <main className="page">
+      <div className="wrap narrow">
+        <Link href="/" className="back-link">
+          ← KafLogへ戻る
+        </Link>
+
+        <header className="people-said-header">
+          <p className="eyebrow">PEOPLE SAID</p>
+          <h1 className="day-title">人から言われたこと</h1>
+          <p className="site-intro">
+            公開を選んだ言葉だけを、逐語引用・要約・推測を混同しない形で残しています。
+          </p>
+        </header>
+
+        {entries.length === 0 ? (
+          <div className="empty-state people-said-empty">
+            <h2>まだ公開された言葉はありません。</h2>
+            <p>非公開の記録や元の会話ログは、このReaderには表示されません。</p>
+          </div>
+        ) : (
+          <ol className="people-said-list">
+            {entries.map(entry => {
+              const date = entry.occurredAt.slice(0, 10)
+              const label = evidenceLevelLabel(entry.evidenceLevel)
+
+              return (
+                <li key={`${entry.id}:${entry.publicationDecisionId}`}>
+                  <article
+                    className={`people-said-card people-said-${entry.evidenceLevel}`}
+                  >
+                    <div className="people-said-meta">
+                      <time dateTime={entry.occurredAt}>{formatDateOnly(date)}</time>
+                      <span className="evidence-badge">{label}</span>
+                    </div>
+
+                    <p className="people-said-context">
+                      {entry.context ?? '文脈は公開していません'}
+                    </p>
+
+                    {entry.evidenceLevel === 'direct_quote' ? (
+                      <blockquote className="people-said-quote">
+                        <p>「{entry.text}」</p>
+                      </blockquote>
+                    ) : (
+                      <p className="people-said-text">{entry.text}</p>
+                    )}
+
+                    <p className="people-said-speaker">
+                      {publicSpeakerLabel(entry.speakerLabel)}
+                    </p>
+
+                    {entry.reaction ? (
+                      <aside className="people-said-reaction">
+                        <span>その時の自分</span>
+                        <p>{entry.reaction}</p>
+                      </aside>
+                    ) : null}
+                  </article>
+                </li>
+              )
+            })}
+          </ol>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/apps/reader/lib/people-said.ts
+++ b/apps/reader/lib/people-said.ts
@@ -1,0 +1,127 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export type EvidenceLevel = 'direct_quote' | 'paraphrase' | 'inferred_impression'
+
+export type PeopleSaidEntry = {
+  id: string
+  publicationDecisionId: string
+  evidenceLevel: EvidenceLevel
+  text: string
+  speakerLabel: string | null
+  occurredAt: string
+  publishedAt: string
+  context: string | null
+  reaction: string | null
+}
+
+const DATA_ROOT = path.resolve(process.cwd(), '..', '..', 'data', 'public')
+const PEOPLE_SAID_FILE = path.join(DATA_ROOT, 'social_mirror.jsonl')
+const EVIDENCE_LEVELS = new Set<EvidenceLevel>([
+  'direct_quote',
+  'paraphrase',
+  'inferred_impression',
+])
+const FORBIDDEN_PUBLIC_KEYS = new Set([
+  'evidence',
+  'source_object_id',
+  'source_excerpt',
+  'transcript',
+  'speaker_entity_id',
+])
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isStringOrNull = (value: unknown): value is string | null =>
+  typeof value === 'string' || value === null
+
+const isIsoDateTime = (value: string) => !Number.isNaN(Date.parse(value))
+
+export const parsePeopleSaidProjection = (value: unknown): PeopleSaidEntry | null => {
+  if (!isObject(value)) return null
+  if ([...FORBIDDEN_PUBLIC_KEYS].some(key => key in value)) return null
+
+  const {
+    claim_id,
+    publication_decision_id,
+    evidence_level,
+    text,
+    speaker_label,
+    occurred_at,
+    published_at,
+    context = null,
+    reaction = null,
+  } = value
+
+  if (typeof claim_id !== 'string' || claim_id.length === 0) return null
+  if (
+    typeof publication_decision_id !== 'string' ||
+    publication_decision_id.length === 0
+  ) {
+    return null
+  }
+  if (
+    typeof evidence_level !== 'string' ||
+    !EVIDENCE_LEVELS.has(evidence_level as EvidenceLevel)
+  ) {
+    return null
+  }
+  if (typeof text !== 'string' || text.trim().length === 0) return null
+  if (!isStringOrNull(speaker_label)) return null
+  if (typeof occurred_at !== 'string' || !isIsoDateTime(occurred_at)) return null
+  if (typeof published_at !== 'string' || !isIsoDateTime(published_at)) return null
+  if (!isStringOrNull(context) || !isStringOrNull(reaction)) return null
+
+  return {
+    id: claim_id,
+    publicationDecisionId: publication_decision_id,
+    evidenceLevel: evidence_level as EvidenceLevel,
+    text: text.trim(),
+    speakerLabel: speaker_label,
+    occurredAt: occurred_at,
+    publishedAt: published_at,
+    context,
+    reaction,
+  }
+}
+
+export const getPeopleSaidEntries = async (
+  filePath = PEOPLE_SAID_FILE,
+): Promise<PeopleSaidEntry[]> => {
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    const entries = raw
+      .split(/\r?\n/)
+      .filter(line => line.trim().length > 0)
+      .map(line => {
+        try {
+          return parsePeopleSaidProjection(JSON.parse(line) as unknown)
+        } catch {
+          return null
+        }
+      })
+      .filter((entry): entry is PeopleSaidEntry => entry !== null)
+
+    return entries.sort((a, b) => b.occurredAt.localeCompare(a.occurredAt))
+  } catch {
+    return []
+  }
+}
+
+export const evidenceLevelLabel = (level: EvidenceLevel) => {
+  switch (level) {
+    case 'direct_quote':
+      return '逐語引用'
+    case 'paraphrase':
+      return '要約'
+    case 'inferred_impression':
+      return '推測'
+  }
+}
+
+export const publicSpeakerLabel = (value: string | null) => {
+  if (value === null) return '話者非公開'
+  if (value === 'unknown') return '話者不明'
+  return value
+}

--- a/apps/reader/package.json
+++ b/apps/reader/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "eslint app lib next.config.ts",
     "design:check": "node scripts/check-design-contract.mjs"

--- a/apps/reader/tests/people-said.test.ts
+++ b/apps/reader/tests/people-said.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  evidenceLevelLabel,
+  getPeopleSaidEntries,
+  parsePeopleSaidProjection,
+  publicSpeakerLabel,
+} from '../lib/people-said'
+
+const tempRoots: string[] = []
+
+const makeTempFile = async (lines: unknown[]) => {
+  const root = await mkdtemp(path.join(tmpdir(), 'kaflog-people-said-'))
+  tempRoots.push(root)
+  const filePath = path.join(root, 'social_mirror.jsonl')
+  await writeFile(
+    filePath,
+    lines.map(line => JSON.stringify(line)).join('\n'),
+    'utf8',
+  )
+  return filePath
+}
+
+const projection = (overrides: Record<string, unknown> = {}) => ({
+  claim_id: '11111111-1111-4111-8111-111111111111',
+  publication_decision_id: '22222222-2222-4222-8222-222222222222',
+  evidence_level: 'direct_quote',
+  text: '詳しすぎる',
+  speaker_label: 'friend-a',
+  occurred_at: '2026-08-01T12:00:00+09:00',
+  published_at: '2026-08-13T19:00:00+09:00',
+  context: 'VRChatで雑談中',
+  reaction: '少し笑った',
+  ...overrides,
+})
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map(root => rm(root, { recursive: true })))
+})
+
+describe('People Said public projection', () => {
+  test('maps only the public projection fields', () => {
+    const entry = parsePeopleSaidProjection(projection())
+
+    expect(entry).toEqual({
+      id: '11111111-1111-4111-8111-111111111111',
+      publicationDecisionId: '22222222-2222-4222-8222-222222222222',
+      evidenceLevel: 'direct_quote',
+      text: '詳しすぎる',
+      speakerLabel: 'friend-a',
+      occurredAt: '2026-08-01T12:00:00+09:00',
+      publishedAt: '2026-08-13T19:00:00+09:00',
+      context: 'VRChatで雑談中',
+      reaction: '少し笑った',
+    })
+  })
+
+  test('rejects any record carrying raw/private source fields', () => {
+    for (const forbidden of [
+      'evidence',
+      'source_object_id',
+      'source_excerpt',
+      'transcript',
+      'speaker_entity_id',
+    ]) {
+      expect(parsePeopleSaidProjection(projection({ [forbidden]: 'private' }))).toBeNull()
+    }
+  })
+
+  test('keeps direct quote, paraphrase, and inference labels distinct', () => {
+    expect(evidenceLevelLabel('direct_quote')).toBe('逐語引用')
+    expect(evidenceLevelLabel('paraphrase')).toBe('要約')
+    expect(evidenceLevelLabel('inferred_impression')).toBe('推測')
+  })
+
+  test('keeps speaker privacy states explicit', () => {
+    expect(publicSpeakerLabel(null)).toBe('話者非公開')
+    expect(publicSpeakerLabel('unknown')).toBe('話者不明')
+    expect(publicSpeakerLabel('friend-a')).toBe('friend-a')
+  })
+
+  test('reads valid public rows, skips unsafe rows, and sorts by occurrence time', async () => {
+    const filePath = await makeTempFile([
+      projection({
+        claim_id: '33333333-3333-4333-8333-333333333333',
+        publication_decision_id: '44444444-4444-4444-8444-444444444444',
+        evidence_level: 'paraphrase',
+        occurred_at: '2026-08-02T10:00:00+09:00',
+      }),
+      projection({
+        claim_id: '55555555-5555-4555-8555-555555555555',
+        publication_decision_id: '66666666-6666-4666-8666-666666666666',
+        transcript: 'raw transcript must not reach the Reader',
+      }),
+      projection({
+        claim_id: '77777777-7777-4777-8777-777777777777',
+        publication_decision_id: '88888888-8888-4888-8888-888888888888',
+        evidence_level: 'inferred_impression',
+        occurred_at: '2026-08-03T10:00:00+09:00',
+        speaker_label: null,
+        context: null,
+        reaction: null,
+      }),
+    ])
+
+    const entries = await getPeopleSaidEntries(filePath)
+
+    expect(entries).toHaveLength(2)
+    expect(entries.map(entry => entry.id)).toEqual([
+      '77777777-7777-4777-8777-777777777777',
+      '33333333-3333-4333-8333-333333333333',
+    ])
+  })
+
+  test('returns an empty state for a missing projection file', async () => {
+    const entries = await getPeopleSaidEntries('/definitely/missing/social_mirror.jsonl')
+    expect(entries).toEqual([])
+  })
+})

--- a/apps/reader/tsconfig.json
+++ b/apps/reader/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }

--- a/packages/privacy/src/vlog_privacy/social_mirror.py
+++ b/packages/privacy/src/vlog_privacy/social_mirror.py
@@ -69,7 +69,10 @@ class SocialMirrorPublicProjection:
     evidence_level: SocialMirrorEvidenceLevel
     text: str
     speaker_label: str | None
+    occurred_at: datetime
     published_at: datetime
+    context: str | None = None
+    reaction: str | None = None
 
 
 def project_social_mirror_claim(
@@ -106,5 +109,6 @@ def project_social_mirror_claim(
         evidence_level=claim.value.evidence_level,
         text=claim.value.text,
         speaker_label=speaker_label,
+        occurred_at=claim.valid_from,
         published_at=decision.decided_at,
     )

--- a/schemas/social-mirror-public-projection.schema.json
+++ b/schemas/social-mirror-public-projection.schema.json
@@ -11,6 +11,7 @@
     "evidence_level",
     "text",
     "speaker_label",
+    "occurred_at",
     "published_at"
   ],
   "properties": {
@@ -22,6 +23,9 @@
     },
     "text": {"type": "string", "minLength": 1},
     "speaker_label": {"type": ["string", "null"]},
-    "published_at": {"type": "string", "format": "date-time"}
+    "occurred_at": {"type": "string", "format": "date-time"},
+    "published_at": {"type": "string", "format": "date-time"},
+    "context": {"type": ["string", "null"]},
+    "reaction": {"type": ["string", "null"]}
   }
 }

--- a/tests/test_social_mirror_privacy.py
+++ b/tests/test_social_mirror_privacy.py
@@ -93,6 +93,9 @@ def test_text_can_be_published_without_speaker_identity() -> None:
     assert projection is not None
     assert projection.text == "詳しすぎると言われた"
     assert projection.speaker_label is None
+    assert projection.occurred_at == claim.valid_from
+    assert projection.context is None
+    assert projection.reaction is None
 
 
 def test_speaker_identity_requires_its_own_explicit_decision() -> None:
@@ -147,7 +150,10 @@ def test_public_projection_excludes_raw_evidence_and_internal_speaker_id() -> No
         "evidence_level",
         "text",
         "speaker_label",
+        "occurred_at",
         "published_at",
+        "context",
+        "reaction",
     }
     assert "evidence" not in payload
     assert "source_excerpt" not in payload
@@ -199,7 +205,10 @@ def test_public_projection_schema_has_no_raw_source_fields() -> None:
         "evidence_level",
         "text",
         "speaker_label",
+        "occurred_at",
         "published_at",
+        "context",
+        "reaction",
     }
     assert properties.isdisjoint(
         {


### PR DESCRIPTION
## Summary

Advances #36. The production desktop/mobile verification remains for #42.

Adds a standalone `People Said / 人から言われたこと` Reader view backed exclusively by the Social Mirror public projection boundary.

### Public-only data boundary
- reads only `data/public/social_mirror.jsonl`
- missing public projection returns an empty state; there is no fallback to canonical/private data
- rejects any input row carrying `evidence`, `source_object_id`, `source_excerpt`, `transcript`, or internal `speaker_entity_id`
- sorts by canonical claim occurrence time, not publication time

### Projection contract
Extends the public projection with `occurred_at` from accepted `MemoryClaim.valid_from` plus optional `context` / `reaction` public annotations. The canonical projector emits those optional annotations as `null`; it never derives them from raw/private evidence.

### Reader semantics
- direct quote: explicit `逐語引用` label + blockquote/quotation treatment
- paraphrase: explicit `要約` label, no quote marks
- inferred impression: explicit `推測` label, no quote marks, separate visual treatment
- speaker public / unknown / hidden states remain distinct
- optional public reaction is shown only when present
- missing context is rendered as `文脈は公開していません`, not inferred
- no image dependency

### Responsive design
Uses the #43/#44 semantic KafLog design tokens with a single-column mobile rule at <=720px. No cyber/neon styling is reintroduced.

### Tests / CI
Adds Bun Reader contract tests and runs them in the existing Reader CI job. Tests cover public field mapping, raw/private-field rejection, evidence-level labels, speaker privacy states, chronological sorting, unsafe-row skipping, and empty projection behavior.

## Remaining acceptance item
Actual desktop/mobile rendering on `kaflog.vercel.app` is intentionally verified in the final production E2E issue #42. This PR therefore does not auto-close #36.