### PR TITLE
Reframe KafLog home as a personal-history Reader

### DIFF
--- a/apps/reader/app/layout.tsx
+++ b/apps/reader/app/layout.tsx
@@ -1,9 +1,11 @@
 import './globals.css'
 import type { Metadata } from 'next'
 
+import { SITE_METADATA } from '@/lib/site-copy'
+
 export const metadata: Metadata = {
-  title: 'VRChat Auto Diary',
-  description: 'VRChatで過ごした時間を読み返す日記',
+  title: SITE_METADATA.title,
+  description: SITE_METADATA.description,
 }
 
 export default function RootLayout({

--- a/apps/reader/app/page.tsx
+++ b/apps/reader/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import { formatDateOnly, getLatestSummaries } from '@/lib/entries'
+import { HOME_COPY } from '@/lib/site-copy'
 
 export default async function Page() {
   const entries = await getLatestSummaries(60)
@@ -9,11 +10,9 @@ export default async function Page() {
     <main className="page">
       <div className="wrap">
         <header className="site-header">
-          <p className="eyebrow">RECENT DAYS</p>
-          <h1 className="site-title">VRChat Auto Diary</h1>
-          <p className="site-intro">
-            VRChatで過ごした時間を、日付ごとの記録として読み返せます。
-          </p>
+          <p className="eyebrow">{HOME_COPY.eyebrow}</p>
+          <h1 className="site-title">{HOME_COPY.title}</h1>
+          <p className="site-intro">{HOME_COPY.intro}</p>
         </header>
 
         {entries.length === 0 ? (

--- a/apps/reader/lib/site-copy.ts
+++ b/apps/reader/lib/site-copy.ts
@@ -1,0 +1,6 @@
+export const HOME_COPY = {
+  eyebrow: 'KAFLOG',
+  title: 'KafLog',
+  intro:
+    '覚えていたい日々。日記、その記憶から生まれた物語、人から言われたこと。公開を選んだ人生の断片を、時間の中に残しています。',
+} as const

--- a/apps/reader/lib/site-copy.ts
+++ b/apps/reader/lib/site-copy.ts
@@ -4,3 +4,8 @@ export const HOME_COPY = {
   intro:
     '覚えていたい日々。日記、その記憶から生まれた物語、人から言われたこと。公開を選んだ人生の断片を、時間の中に残しています。',
 } as const
+
+export const SITE_METADATA = {
+  title: 'KafLog',
+  description: '公開を選んだ日記、物語、人から言われたことを時間の中で読み返す個人史Reader',
+} as const

--- a/apps/reader/tests/site-copy.test.ts
+++ b/apps/reader/tests/site-copy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+
+import { HOME_COPY } from '../lib/site-copy'
+
+describe('KafLog home identity', () => {
+  test('uses KafLog as the public Reader identity', () => {
+    expect(HOME_COPY.eyebrow).toBe('KAFLOG')
+    expect(HOME_COPY.title).toBe('KafLog')
+  })
+
+  test('explains the three ways of reading memory without technical framing', () => {
+    expect(HOME_COPY.intro).toContain('日記')
+    expect(HOME_COPY.intro).toContain('物語')
+    expect(HOME_COPY.intro).toContain('人から言われたこと')
+    expect(HOME_COPY.intro).toContain('公開を選んだ人生の断片')
+  })
+
+  test('does not restore the old AI-tool identity in hero copy', () => {
+    const copy = JSON.stringify(HOME_COPY)
+
+    expect(copy).not.toContain('VRChat Auto Diary')
+    expect(copy).not.toContain('Gemini')
+    expect(copy).not.toContain('Supabase')
+    expect(copy).not.toContain('AI生成')
+  })
+})

--- a/apps/reader/tests/site-copy.test.ts
+++ b/apps/reader/tests/site-copy.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { HOME_COPY } from '../lib/site-copy'
+import { HOME_COPY, SITE_METADATA } from '../lib/site-copy'
 
 describe('KafLog home identity', () => {
   test('uses KafLog as the public Reader identity', () => {
     expect(HOME_COPY.eyebrow).toBe('KAFLOG')
     expect(HOME_COPY.title).toBe('KafLog')
+    expect(SITE_METADATA.title).toBe('KafLog')
   })
 
   test('explains the three ways of reading memory without technical framing', () => {
@@ -13,10 +14,11 @@ describe('KafLog home identity', () => {
     expect(HOME_COPY.intro).toContain('物語')
     expect(HOME_COPY.intro).toContain('人から言われたこと')
     expect(HOME_COPY.intro).toContain('公開を選んだ人生の断片')
+    expect(SITE_METADATA.description).toContain('個人史Reader')
   })
 
-  test('does not restore the old AI-tool identity in hero copy', () => {
-    const copy = JSON.stringify(HOME_COPY)
+  test('does not restore the old AI-tool identity in public identity copy', () => {
+    const copy = JSON.stringify({ HOME_COPY, SITE_METADATA })
 
     expect(copy).not.toContain('VRChat Auto Diary')
     expect(copy).not.toContain('Gemini')


### PR DESCRIPTION
## Summary

Advances #37. Production desktop/mobile verification remains for #42.

Reframes the Reader home from `VRChat Auto Diary` to the KafLog identity without changing navigation or data behavior.

### Home identity
- eyebrow: `KAFLOG`
- title: `KafLog`
- intro explains the archive through Diary, stories derived from memory, and People Said
- emphasizes that the site contains life fragments explicitly chosen for publication
- removes VRChat/AI-tool framing from the hero copy

### Scope control
The copy is isolated in `lib/site-copy.ts`; this PR does not redesign navigation, Timeline, Social Mirror extraction, or publication logic.

### Contract test
Bun tests require the copy to:
- use KafLog as the public identity
- mention 日記 / 物語 / 人から言われたこと
- explain `公開を選んだ人生の断片`
- reject reintroduction of `VRChat Auto Diary`, Gemini, Supabase, or `AI生成` in hero copy

## Remaining acceptance item
Actual desktop/mobile rendering and production copy verification on `kaflog.vercel.app` are intentionally consolidated into #42, so this PR does not auto-close #37.