### PR TITLE
Organize KafLog navigation by ways of reading memory

### DIFF
--- a/apps/reader/app/layout.tsx
+++ b/apps/reader/app/layout.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next'
 
 import { SITE_METADATA } from '@/lib/site-copy'
 
+import SiteNav from './site-nav'
+
 export const metadata: Metadata = {
   title: SITE_METADATA.title,
   description: SITE_METADATA.description,
@@ -15,7 +17,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        <SiteNav />
+        {children}
+      </body>
     </html>
   )
 }

--- a/apps/reader/app/site-nav.module.css
+++ b/apps/reader/app/site-nav.module.css
@@ -1,0 +1,116 @@
+.shell {
+  position: relative;
+  z-index: 10;
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-canvas) 94%, transparent);
+}
+
+.inner {
+  width: min(1080px, calc(100% - 32px));
+  min-height: 60px;
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  margin: 0 auto;
+}
+
+.brand {
+  flex: 0 0 auto;
+  color: var(--color-ink);
+  font-weight: 800;
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+}
+
+.items {
+  min-width: 0;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-left: auto;
+  list-style: none;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.link,
+.disabled {
+  min-height: 44px;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.link {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+  transition:
+    color var(--motion-fast) var(--ease-standard),
+    background-color var(--motion-fast) var(--ease-standard);
+}
+
+.link:hover {
+  color: var(--color-ink);
+  background: var(--color-paper-soft);
+}
+
+.link[aria-current='page'] {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.link:focus-visible,
+.brand:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.disabled {
+  color: var(--color-ink-subtle);
+  cursor: default;
+  opacity: 0.72;
+}
+
+.soon {
+  color: var(--color-ink-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .inner {
+    width: 100%;
+    min-height: auto;
+    display: block;
+    padding: 10px 16px 8px;
+  }
+
+  .brand {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .items {
+    width: 100%;
+    gap: 2px;
+    padding-bottom: 4px;
+    margin-left: 0;
+  }
+
+  .link,
+  .disabled {
+    padding: 0 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link {
+    transition: none;
+  }
+}

--- a/apps/reader/app/site-nav.tsx
+++ b/apps/reader/app/site-nav.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import {
+  PRIMARY_NAVIGATION,
+  navigationItemIsActive,
+} from '@/lib/navigation'
+
+import styles from './site-nav.module.css'
+
+export default function SiteNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav className={styles.shell} aria-label="KafLogの記憶を読む">
+      <div className={styles.inner}>
+        <Link href="/" className={styles.brand} aria-label="KafLog ホーム">
+          KafLog
+        </Link>
+
+        <ul className={styles.items}>
+          {PRIMARY_NAVIGATION.map(item => {
+            const active = navigationItemIsActive(item, pathname)
+
+            return (
+              <li key={item.key}>
+                {item.href ? (
+                  <Link
+                    href={item.href}
+                    className={styles.link}
+                    aria-current={active ? 'page' : undefined}
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={styles.disabled}
+                    aria-disabled="true"
+                    title="この読み方は準備中です"
+                  >
+                    {item.label}
+                    <span className={styles.soon}>準備中</span>
+                  </span>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </nav>
+  )
+}

--- a/apps/reader/lib/navigation.ts
+++ b/apps/reader/lib/navigation.ts
@@ -1,0 +1,38 @@
+export type NavigationItem = {
+  key: 'timeline' | 'diaries' | 'novels' | 'people-said'
+  label: string
+  href: string | null
+  activePrefixes: readonly string[]
+}
+
+export const PRIMARY_NAVIGATION: readonly NavigationItem[] = [
+  {
+    key: 'timeline',
+    label: 'Timeline',
+    href: null,
+    activePrefixes: ['/timeline'],
+  },
+  {
+    key: 'diaries',
+    label: 'Diaries',
+    href: '/',
+    activePrefixes: ['/', '/day/'],
+  },
+  {
+    key: 'novels',
+    label: 'Novels',
+    href: null,
+    activePrefixes: ['/novels'],
+  },
+  {
+    key: 'people-said',
+    label: 'People Said',
+    href: '/people-said',
+    activePrefixes: ['/people-said'],
+  },
+] as const
+
+export const navigationItemIsActive = (item: NavigationItem, pathname: string) => {
+  if (item.key === 'diaries' && pathname === '/') return true
+  return item.activePrefixes.some(prefix => prefix !== '/' && pathname.startsWith(prefix))
+}

--- a/apps/reader/tests/navigation.test.ts
+++ b/apps/reader/tests/navigation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  PRIMARY_NAVIGATION,
+  navigationItemIsActive,
+} from '../lib/navigation'
+
+describe('KafLog primary navigation', () => {
+  test('defines the four memory-reading modes in canonical order', () => {
+    expect(PRIMARY_NAVIGATION.map(item => item.label)).toEqual([
+      'Timeline',
+      'Diaries',
+      'Novels',
+      'People Said',
+    ])
+  })
+
+  test('links only routes that currently exist', () => {
+    const byKey = Object.fromEntries(
+      PRIMARY_NAVIGATION.map(item => [item.key, item.href]),
+    )
+
+    expect(byKey.timeline).toBeNull()
+    expect(byKey.diaries).toBe('/')
+    expect(byKey.novels).toBeNull()
+    expect(byKey['people-said']).toBe('/people-said')
+  })
+
+  test('never creates duplicate enabled hrefs', () => {
+    const hrefs = PRIMARY_NAVIGATION.flatMap(item =>
+      item.href === null ? [] : [item.href],
+    )
+
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+
+  test('marks diary home and detail URLs as Diaries', () => {
+    const diaries = PRIMARY_NAVIGATION.find(item => item.key === 'diaries')!
+
+    expect(navigationItemIsActive(diaries, '/')).toBeTrue()
+    expect(navigationItemIsActive(diaries, '/day/2026-08-13')).toBeTrue()
+    expect(navigationItemIsActive(diaries, '/people-said')).toBeFalse()
+  })
+
+  test('marks People Said only on its route family', () => {
+    const peopleSaid = PRIMARY_NAVIGATION.find(
+      item => item.key === 'people-said',
+    )!
+
+    expect(navigationItemIsActive(peopleSaid, '/people-said')).toBeTrue()
+    expect(navigationItemIsActive(peopleSaid, '/people-said/example')).toBeTrue()
+    expect(navigationItemIsActive(peopleSaid, '/')).toBeFalse()
+  })
+})


### PR DESCRIPTION
## Summary

Advances #38. Production keyboard/mobile verification remains consolidated in #42.

Adds one global KafLog navigation organized by the four intended ways of reading memory:

`Timeline / Diaries / Novels / People Said`

### Staged navigation
- `Diaries` links to the existing `/` archive and remains active for `/day/...` permalinks
- `People Said` links to the implemented `/people-said` view
- `Timeline` and `Novels` are explicitly disabled with `aria-disabled="true"` and `準備中` rather than pointing at nonexistent routes
- later #39/#40 work can enable those hrefs without redesigning the navigation model

### Current location
A single global `SiteNav` uses pathname-aware `aria-current="page"` for enabled route families.

### Keyboard/mobile
- enabled items remain ordinary semantic links
- author-defined 3px focus outline uses the canonical KafLog focus token
- tap targets are at least 44px tall
- mobile navigation is a horizontally scrollable single row instead of wrapping into a broken multi-line toolbar
- reduced-motion mode removes navigation transition effects

### No duplicated navigation architecture
The primary navigation is rendered once from the root layout. Existing content permalinks are unchanged.

### Contract tests
Bun tests fix:
- canonical four-item order
- current enabled/disabled route state
- no duplicate enabled hrefs
- Diary home/detail active matching
- People Said active matching

## Scope
No Timeline content, Novel content, home-copy change, or Social Mirror extraction is implemented here.