### PR TITLE
Distinguish Diary and Novel in the public Reader

### DIFF
--- a/apps/reader/README.md
+++ b/apps/reader/README.md
@@ -10,9 +10,15 @@ Implementation changes should consume semantic tokens rather than introducing co
 
 ## Public projection inputs
 
-The Reader consumes public projections only. `People Said / 人から言われたこと` reads `data/public/social_mirror.jsonl` when that projection exists.
+The Reader consumes public projections only.
 
-Each row follows `schemas/social-mirror-public-projection.schema.json`. Reader parsing rejects records that carry raw/private source fields such as `EvidenceRef`, source-object IDs, transcript text, source excerpts, or internal speaker entity IDs. Missing projection files produce an empty state rather than falling back to canonical/private data.
+- Diary uses the current public Diary/local-development archive boundary and keeps `/day/[date]` as its detail route.
+- Novel reads public rows from the historical `novels` projection using the public Supabase anon boundary. `is_public=eq.true` is part of the request, explicitly private rows are rejected defensively, and `/novels/[id]` uses the canonical Novel row ID as the stable permalink. `image_url` is optional; older public rows without that field remain readable.
+- `People Said / 人から言われたこと` reads `data/public/social_mirror.jsonl` when that projection exists.
+
+Diary and Novel are both narrative artifacts, but they are not presented as the same kind of record. Diary is a human-readable record of a day rather than raw Evidence; Novel is explicitly labeled as a creative derivative from memory rather than a factual record.
+
+People Said rows follow `schemas/social-mirror-public-projection.schema.json`. Reader parsing rejects records that carry raw/private source fields such as `EvidenceRef`, source-object IDs, transcript text, source excerpts, or internal speaker entity IDs. Missing projection files produce an empty state rather than falling back to canonical/private data.
 
 `context` and `reaction` are optional public-projection annotations. Their absence is displayed as absence; the Reader does not infer either value from a quote, Diary, or raw source.
 

--- a/apps/reader/app/day/[date]/page.tsx
+++ b/apps/reader/app/day/[date]/page.tsx
@@ -32,16 +32,19 @@ export default async function DayPage({ params }: Props) {
         {entry === null ? (
           <div className="empty-state">
             <h1>日記が見つかりません</h1>
-            <p>{formatDateOnly(date)} のローカルデータはありません。</p>
+            <p>{formatDateOnly(date)} の公開日記はありません。</p>
           </div>
         ) : (
           <>
             <header className="day-header">
-              <p className="eyebrow">VRCHAT DIARY</p>
+              <p className="eyebrow">DIARY / 日記</p>
               <h1 className="day-title">{entry.title}</h1>
               <time className="day-date" dateTime={date}>
                 {formatDateOnly(date)}
               </time>
+              <p className="artifact-note">
+                その日の出来事を読み返すためにまとめた記録です。会話や写真などの元記録そのものではありません。
+              </p>
             </header>
             <article className="entry-copy">
               <p className="entry-body">{entry.content}</p>

--- a/apps/reader/app/day/[date]/page.tsx
+++ b/apps/reader/app/day/[date]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 
+import { ARTIFACT_SEMANTICS } from '@/lib/artifact-semantics'
 import {
   formatDateOnly,
   getLatestSummaries,
@@ -37,13 +38,13 @@ export default async function DayPage({ params }: Props) {
         ) : (
           <>
             <header className="day-header">
-              <p className="eyebrow">DIARY / 日記</p>
+              <p className="eyebrow">{ARTIFACT_SEMANTICS.diary.label}</p>
               <h1 className="day-title">{entry.title}</h1>
               <time className="day-date" dateTime={date}>
                 {formatDateOnly(date)}
               </time>
               <p className="artifact-note">
-                その日の出来事を読み返すためにまとめた記録です。会話や写真などの元記録そのものではありません。
+                {ARTIFACT_SEMANTICS.diary.description}
               </p>
             </header>
             <article className="entry-copy">

--- a/apps/reader/app/globals.css
+++ b/apps/reader/app/globals.css
@@ -194,6 +194,14 @@ h2 {
   margin-top: 18px;
 }
 
+.artifact-note {
+  max-width: 40rem;
+  margin-top: 20px;
+  color: var(--color-ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.8;
+}
+
 .entry-copy {
   padding-top: 36px;
 }

--- a/apps/reader/app/novels/[id]/page.module.css
+++ b/apps/reader/app/novels/[id]/page.module.css
@@ -1,0 +1,26 @@
+.kind {
+  margin-bottom: 10px;
+  color: var(--color-novel);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.note {
+  max-width: 40rem;
+  margin-top: 20px;
+  color: var(--color-ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.8;
+}
+
+.figure {
+  margin-top: 32px;
+}
+
+.figure img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}

--- a/apps/reader/app/novels/[id]/page.tsx
+++ b/apps/reader/app/novels/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import { ARTIFACT_SEMANTICS } from '@/lib/artifact-semantics'
 import { formatDateOnly } from '@/lib/entries'
 import { getPublicNovelById, getPublicNovels } from '@/lib/novels'
 
@@ -38,13 +39,13 @@ export default async function NovelPage({ params }: Props) {
         ) : (
           <>
             <header className="day-header">
-              <p className={styles.kind}>NOVEL / 物語</p>
+              <p className={styles.kind}>{ARTIFACT_SEMANTICS.novel.label}</p>
               <h1 className="day-title">{novel.title}</h1>
               <time className="day-date" dateTime={novel.date}>
                 {formatDateOnly(novel.date)}
               </time>
               <p className={styles.note}>
-                この文章は記憶をもとに後から物語として書いた創作です。日記や元の会話・写真そのものとは区別して読めるようにしています。
+                {ARTIFACT_SEMANTICS.novel.detailDescription}
               </p>
             </header>
 

--- a/apps/reader/app/novels/[id]/page.tsx
+++ b/apps/reader/app/novels/[id]/page.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable @next/next/no-img-element */
+
+import Link from 'next/link'
+
+import { formatDateOnly } from '@/lib/entries'
+import { getPublicNovelById, getPublicNovels } from '@/lib/novels'
+
+import styles from './page.module.css'
+
+type Props = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function generateStaticParams() {
+  return (await getPublicNovels(60)).map(novel => ({ id: novel.id }))
+}
+
+export const dynamicParams = false
+
+export default async function NovelPage({ params }: Props) {
+  const { id } = await params
+  const novel = await getPublicNovelById(id)
+
+  return (
+    <main className="page">
+      <div className="wrap narrow">
+        <Link className="back-link" href="/novels">
+          ← 物語一覧
+        </Link>
+
+        {novel === null ? (
+          <div className="empty-state">
+            <h1>物語が見つかりません</h1>
+            <p>公開対象のNovelとして取得できませんでした。</p>
+          </div>
+        ) : (
+          <>
+            <header className="day-header">
+              <p className={styles.kind}>NOVEL / 物語</p>
+              <h1 className="day-title">{novel.title}</h1>
+              <time className="day-date" dateTime={novel.date}>
+                {formatDateOnly(novel.date)}
+              </time>
+              <p className={styles.note}>
+                この文章は記憶をもとに後から物語として書いた創作です。日記や元の会話・写真そのものとは区別して読めるようにしています。
+              </p>
+            </header>
+
+            {novel.imageUrl ? (
+              <figure className={styles.figure}>
+                <img src={novel.imageUrl} alt="" loading="lazy" />
+              </figure>
+            ) : null}
+
+            <article className="entry-copy">
+              <p className="entry-body">{novel.content}</p>
+            </article>
+          </>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/apps/reader/app/novels/page.module.css
+++ b/apps/reader/app/novels/page.module.css
@@ -1,0 +1,10 @@
+.novelCard {
+  border-left: 4px solid var(--color-novel);
+}
+
+.kind {
+  margin-bottom: 8px;
+  color: var(--color-novel);
+  font-size: 0.75rem;
+  font-weight: 800;
+}

--- a/apps/reader/app/novels/page.tsx
+++ b/apps/reader/app/novels/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+
+import { formatDateOnly } from '@/lib/entries'
+import { getPublicNovels } from '@/lib/novels'
+
+import styles from './page.module.css'
+
+export default async function NovelsPage() {
+  const novels = await getPublicNovels(60)
+
+  return (
+    <main className="page">
+      <div className="wrap">
+        <header className="site-header">
+          <p className="eyebrow">NOVEL / 物語</p>
+          <h1 className="site-title">記憶から生まれた物語</h1>
+          <p className="site-intro">
+            日々の記憶をもとに、あとから物語として書いた創作です。事実記録としてではなく、記憶から派生したNarrative Artifactとして読める形で残しています。
+          </p>
+        </header>
+
+        {novels.length === 0 ? (
+          <div className="empty-state">
+            <h2>公開された物語はまだありません。</h2>
+            <p>非公開のNovelをReaderへ補完表示することはありません。</p>
+          </div>
+        ) : (
+          <ol className="entries">
+            {novels.map(novel => {
+              const preview = novel.content.replace(/\s+/g, ' ').slice(0, 140)
+
+              return (
+                <li key={novel.id}>
+                  <Link
+                    href={`/novels/${novel.id}`}
+                    className={`${styles.novelCard} entry-link`}
+                    aria-label={`${formatDateOnly(novel.date)}の物語「${novel.title}」を読む`}
+                  >
+                    <span className={styles.kind}>Novel / 物語</span>
+                    <time className="entry-date" dateTime={novel.date}>
+                      {formatDateOnly(novel.date)}
+                    </time>
+                    <strong className="entry-title">{novel.title}</strong>
+                    <span className="entry-preview">{preview}</span>
+                    <span className="entry-action" aria-hidden="true">
+                      物語を読む →
+                    </span>
+                  </Link>
+                </li>
+              )
+            })}
+          </ol>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/apps/reader/app/novels/page.tsx
+++ b/apps/reader/app/novels/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 import { formatDateOnly } from '@/lib/entries'
-import { getPublicNovels } from '@/lib/novels'
+import { getPublicNovels, novelPermalink } from '@/lib/novels'
 
 import styles from './page.module.css'
 
@@ -32,7 +32,7 @@ export default async function NovelsPage() {
               return (
                 <li key={novel.id}>
                   <Link
-                    href={`/novels/${novel.id}`}
+                    href={novelPermalink(novel.id)}
                     className={`${styles.novelCard} entry-link`}
                     aria-label={`${formatDateOnly(novel.date)}の物語「${novel.title}」を読む`}
                   >

--- a/apps/reader/app/novels/page.tsx
+++ b/apps/reader/app/novels/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 
+import { ARTIFACT_SEMANTICS } from '@/lib/artifact-semantics'
 import { formatDateOnly } from '@/lib/entries'
 import { getPublicNovels, novelPermalink } from '@/lib/novels'
 
@@ -12,10 +13,10 @@ export default async function NovelsPage() {
     <main className="page">
       <div className="wrap">
         <header className="site-header">
-          <p className="eyebrow">NOVEL / 物語</p>
+          <p className="eyebrow">{ARTIFACT_SEMANTICS.novel.label}</p>
           <h1 className="site-title">記憶から生まれた物語</h1>
           <p className="site-intro">
-            日々の記憶をもとに、あとから物語として書いた創作です。事実記録としてではなく、記憶から派生したNarrative Artifactとして読める形で残しています。
+            {ARTIFACT_SEMANTICS.novel.archiveDescription}
           </p>
         </header>
 

--- a/apps/reader/lib/artifact-semantics.ts
+++ b/apps/reader/lib/artifact-semantics.ts
@@ -1,0 +1,14 @@
+export const ARTIFACT_SEMANTICS = {
+  diary: {
+    label: 'DIARY / 日記',
+    description:
+      'その日の出来事を読み返すためにまとめた記録です。会話や写真などの元記録そのものではありません。',
+  },
+  novel: {
+    label: 'NOVEL / 物語',
+    archiveDescription:
+      '日々の記憶をもとに、あとから物語として書いた創作です。事実記録としてではなく、記憶から派生したNarrative Artifactとして読める形で残しています。',
+    detailDescription:
+      'この文章は記憶をもとに後から物語として書いた創作です。日記や元の会話・写真そのものとは区別して読めるようにしています。',
+  },
+} as const

--- a/apps/reader/lib/navigation.ts
+++ b/apps/reader/lib/navigation.ts
@@ -21,7 +21,7 @@ export const PRIMARY_NAVIGATION: readonly NavigationItem[] = [
   {
     key: 'novels',
     label: 'Novels',
-    href: null,
+    href: '/novels',
     activePrefixes: ['/novels'],
   },
   {

--- a/apps/reader/lib/novels.ts
+++ b/apps/reader/lib/novels.ts
@@ -1,0 +1,100 @@
+export type PublicNovel = {
+  id: string
+  date: string
+  title: string
+  content: string
+  tags: string[]
+  imageUrl: string | null
+}
+
+type FetchLike = typeof fetch
+
+const getSupabaseConfig = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '')
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  return url && key ? { url, key } : null
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const parseTags = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((tag): tag is string => typeof tag === 'string') : []
+
+export const parsePublicNovel = (value: unknown): PublicNovel | null => {
+  if (!isObject(value)) return null
+
+  const { id, date, title, content, tags = [], image_url = null, is_public } = value
+
+  if (is_public === false) return null
+  if (typeof id !== 'string' || id.length === 0) return null
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
+  if (typeof title !== 'string' || title.trim().length === 0) return null
+  if (typeof content !== 'string' || content.trim().length === 0) return null
+  if (image_url !== null && typeof image_url !== 'string') return null
+
+  return {
+    id,
+    date,
+    title: title.trim(),
+    content: content.trim(),
+    tags: parseTags(tags),
+    imageUrl: image_url,
+  }
+}
+
+const fetchNovelRows = async (
+  select: string,
+  limit: number,
+  fetchImpl: FetchLike,
+): Promise<unknown[] | null> => {
+  const config = getSupabaseConfig()
+  if (!config) return null
+
+  const params = new URLSearchParams({
+    select,
+    is_public: 'eq.true',
+    order: 'date.desc',
+    limit: String(limit),
+  })
+  const response = await fetchImpl(`${config.url}/rest/v1/novels?${params}`, {
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+    },
+    cache: 'no-store',
+  })
+  if (!response.ok) return null
+
+  const payload = (await response.json()) as unknown
+  return Array.isArray(payload) ? payload : null
+}
+
+export const getPublicNovels = async (
+  limit = 60,
+  fetchImpl: FetchLike = fetch,
+): Promise<PublicNovel[]> => {
+  const preferred = await fetchNovelRows(
+    'id,date,title,content,tags,image_url,is_public',
+    limit,
+    fetchImpl,
+  )
+  const rows =
+    preferred ??
+    (await fetchNovelRows('id,date,title,content,tags,is_public', limit, fetchImpl))
+
+  if (rows === null) return []
+
+  const seen = new Set<string>()
+  return rows.flatMap(row => {
+    const novel = parsePublicNovel(row)
+    if (novel === null || seen.has(novel.id)) return []
+    seen.add(novel.id)
+    return [novel]
+  })
+}
+
+export const getPublicNovelById = async (id: string): Promise<PublicNovel | null> => {
+  const novels = await getPublicNovels(60)
+  return novels.find(novel => novel.id === id) ?? null
+}

--- a/apps/reader/lib/novels.ts
+++ b/apps/reader/lib/novels.ts
@@ -19,7 +19,11 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
 const parseTags = (value: unknown): string[] =>
-  Array.isArray(value) ? value.filter((tag): tag is string => typeof tag === 'string') : []
+  Array.isArray(value)
+    ? value.filter((tag): tag is string => typeof tag === 'string')
+    : []
+
+export const novelPermalink = (id: string) => `/novels/${encodeURIComponent(id)}`
 
 export const parsePublicNovel = (value: unknown): PublicNovel | null => {
   if (!isObject(value)) return null

--- a/apps/reader/tests/artifact-semantics.test.ts
+++ b/apps/reader/tests/artifact-semantics.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+
+import { ARTIFACT_SEMANTICS } from '../lib/artifact-semantics'
+
+describe('Diary and Novel semantics', () => {
+  test('labels Diary and Novel as different artifact kinds', () => {
+    expect(ARTIFACT_SEMANTICS.diary.label).toBe('DIARY / 日記')
+    expect(ARTIFACT_SEMANTICS.novel.label).toBe('NOVEL / 物語')
+  })
+
+  test('does not present Diary as raw canonical evidence', () => {
+    expect(ARTIFACT_SEMANTICS.diary.description).toContain('元記録そのものではありません')
+  })
+
+  test('explicitly presents Novel as a creative derivative rather than fact record', () => {
+    expect(ARTIFACT_SEMANTICS.novel.archiveDescription).toContain('創作')
+    expect(ARTIFACT_SEMANTICS.novel.archiveDescription).toContain('事実記録としてではなく')
+    expect(ARTIFACT_SEMANTICS.novel.archiveDescription).toContain('Narrative Artifact')
+    expect(ARTIFACT_SEMANTICS.novel.detailDescription).toContain('創作')
+    expect(ARTIFACT_SEMANTICS.novel.detailDescription).toContain('日記や元の会話・写真そのものとは区別')
+  })
+})

--- a/apps/reader/tests/navigation.test.ts
+++ b/apps/reader/tests/navigation.test.ts
@@ -22,7 +22,7 @@ describe('KafLog primary navigation', () => {
 
     expect(byKey.timeline).toBeNull()
     expect(byKey.diaries).toBe('/')
-    expect(byKey.novels).toBeNull()
+    expect(byKey.novels).toBe('/novels')
     expect(byKey['people-said']).toBe('/people-said')
   })
 
@@ -40,6 +40,19 @@ describe('KafLog primary navigation', () => {
     expect(navigationItemIsActive(diaries, '/')).toBeTrue()
     expect(navigationItemIsActive(diaries, '/day/2026-08-13')).toBeTrue()
     expect(navigationItemIsActive(diaries, '/people-said')).toBeFalse()
+  })
+
+  test('marks Novel list and detail URLs as Novels', () => {
+    const novels = PRIMARY_NAVIGATION.find(item => item.key === 'novels')!
+
+    expect(navigationItemIsActive(novels, '/novels')).toBeTrue()
+    expect(
+      navigationItemIsActive(
+        novels,
+        '/novels/11111111-1111-4111-8111-111111111111',
+      ),
+    ).toBeTrue()
+    expect(navigationItemIsActive(novels, '/')).toBeFalse()
   })
 
   test('marks People Said only on its route family', () => {

--- a/apps/reader/tests/novels.test.ts
+++ b/apps/reader/tests/novels.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  getPublicNovels,
+  novelPermalink,
+  parsePublicNovel,
+} from '../lib/novels'
+
+const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const originalKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+afterEach(() => {
+  if (originalUrl === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL
+  else process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl
+
+  if (originalKey === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  else process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalKey
+})
+
+const publicRow = (overrides: Record<string, unknown> = {}) => ({
+  id: '11111111-1111-4111-8111-111111111111',
+  date: '2026-08-01',
+  title: '記憶から生まれた物語',
+  content: 'これは記憶をもとにした物語です。',
+  tags: ['memory'],
+  image_url: null,
+  is_public: true,
+  ...overrides,
+})
+
+describe('Novel public projection', () => {
+  test('rejects explicitly private rows', () => {
+    expect(parsePublicNovel(publicRow({ is_public: false }))).toBeNull()
+  })
+
+  test('maps optional public image without requiring it', () => {
+    expect(parsePublicNovel(publicRow())?.imageUrl).toBeNull()
+    expect(
+      parsePublicNovel(
+        publicRow({ image_url: 'https://example.invalid/public/novel.webp' }),
+      )?.imageUrl,
+    ).toBe('https://example.invalid/public/novel.webp')
+  })
+
+  test('uses the historical Novel id as the stable permalink key', () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    expect(novelPermalink(id)).toBe(`/novels/${id}`)
+  })
+
+  test('queries only public rows and deduplicates the canonical Novel id', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://project.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'public-anon-key'
+
+    const calls: string[] = []
+    const fetchMock = (async (input: RequestInfo | URL) => {
+      calls.push(String(input))
+      return new Response(JSON.stringify([publicRow(), publicRow()]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const novels = await getPublicNovels(60, fetchMock)
+
+    expect(novels).toHaveLength(1)
+    expect(calls).toHaveLength(1)
+    const url = new URL(calls[0])
+    expect(url.pathname).toBe('/rest/v1/novels')
+    expect(url.searchParams.get('is_public')).toBe('eq.true')
+    expect(url.searchParams.get('order')).toBe('date.desc')
+    expect(url.searchParams.get('limit')).toBe('60')
+  })
+
+  test('falls back when a legacy table has no image_url column', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://project.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'public-anon-key'
+
+    let call = 0
+    const fetchMock = (async () => {
+      call += 1
+      if (call === 1) return new Response('missing image_url', { status: 400 })
+      return new Response(
+        JSON.stringify([
+          {
+            id: '22222222-2222-4222-8222-222222222222',
+            date: '2026-08-02',
+            title: 'Legacy Novel',
+            content: 'legacy public content',
+            tags: [],
+            is_public: true,
+          },
+        ]),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as typeof fetch
+
+    const novels = await getPublicNovels(60, fetchMock)
+
+    expect(call).toBe(2)
+    expect(novels).toHaveLength(1)
+    expect(novels[0].imageUrl).toBeNull()
+  })
+
+  test('returns an empty public archive when Supabase public config is absent', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    const novels = await getPublicNovels()
+    expect(novels).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Advances #39. Production desktop/mobile verification remains consolidated in #42.

### Meaning contract
- Diary is labeled `DIARY / 日記` and explicitly described as a human-readable record of the day, not raw Evidence itself.
- Novel is labeled `NOVEL / 物語` and explicitly described as a creative derivative from memory / Narrative Artifact, not a factual record.
- the distinction is textual and structural, not color-only.

### Novel public archive
Restores a Reader-side Novel path using the historical public `novels` projection contract (`id/date/title/content/tags/is_public`) verified in repository history.

- `/novels` public list
- `/novels/[id]` stable detail permalink using the historical canonical Novel row `id`
- `is_public=eq.true` on the Supabase request plus defensive rejection of explicit private rows
- optional `image_url`; if that column is absent, the loader retries the historical field set and remains readable without images
- missing public Supabase config produces an empty public archive rather than falling back to private data

### Historical permalink correction
The issue originally said to preserve an existing Novel permalink. Audit found no verifiable existing Novel detail URL in current `main`, detached public-archive recovery `ab00172`, or the 2025 Novel integration; the historical UI used an in-list modal. This is recorded on #39. Existing Diary `/day/[date]` is preserved, and `/novels/[id]` is established as the stable Novel URL.

### Navigation
`Novels` is enabled in the existing Timeline / Diaries / Novels / People Said navigation without changing the other route families.

### Tests
Bun contracts cover:
- Diary vs Novel semantic labels/descriptions
- explicit private Novel rejection
- optional image behavior
- stable ID permalink
- public-only Supabase query
- duplicate ID collapse
- legacy table fallback without `image_url`
- Novel list/detail active navigation

## Remaining acceptance item
Actual desktop/mobile rendering and live public data/permalink/image verification are deferred to final production E2E #42. This PR therefore does not auto-close #39.