### PR TITLE
Lock public Reader pagination and privacy boundaries

### DIFF
--- a/apps/reader/lib/entries.ts
+++ b/apps/reader/lib/entries.ts
@@ -1,9 +1,15 @@
 import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 
+import {
+  PUBLICATION_START_DATE,
+  getRemotePublicArchiveEntries,
+} from './public-archive'
+
 export type Entry = {
   id: string
   date: string
+  imageUrl: string | null
   title: string
   content: string
 }
@@ -72,13 +78,16 @@ const cleanContent = (content: string) => {
 const readSummary = async (fileName: string): Promise<Entry | null> => {
   const match = fileName.match(SUMMARY_FILE)
   if (!match) return null
-  if (!(await isPublishableSummary(match[1]))) return null
 
   const date = toDate(match[1])
+  if (date < PUBLICATION_START_DATE) return null
+  if (!(await isPublishableSummary(match[1]))) return null
+
   const content = await readText(path.join(SUMMARY_DIR, fileName))
   return {
     id: `summary:${date}`,
     date,
+    imageUrl: null,
     title: parseTitle(content),
     content: cleanContent(content),
   }
@@ -92,7 +101,12 @@ export const formatDateOnly = (value: string) => {
   }).format(new Date(`${value}T00:00:00`))
 }
 
-export const getLatestSummaries = async (limit = 60): Promise<Entry[]> => {
+export const getLatestSummaries = async (limit?: number): Promise<Entry[]> => {
+  const remoteEntries = await getRemotePublicArchiveEntries('diary')
+  if (remoteEntries !== null) {
+    return limit === undefined ? remoteEntries : remoteEntries.slice(0, limit)
+  }
+
   try {
     const files = await readdir(SUMMARY_DIR)
     const summaries = await Promise.all(
@@ -101,14 +115,21 @@ export const getLatestSummaries = async (limit = 60): Promise<Entry[]> => {
         .sort((a, b) => b.localeCompare(a))
         .map(readSummary),
     )
-
-    return summaries.filter((entry): entry is Entry => entry !== null).slice(0, limit)
+    const published = summaries.filter((entry): entry is Entry => entry !== null)
+    return limit === undefined ? published : published.slice(0, limit)
   } catch {
     return []
   }
 }
 
 export const getSummaryByDate = async (date: string): Promise<Entry | null> => {
+  if (date < PUBLICATION_START_DATE) return null
+
+  const remoteEntries = await getRemotePublicArchiveEntries('diary')
+  if (remoteEntries !== null) {
+    return remoteEntries.find(entry => entry.date === date) ?? null
+  }
+
   try {
     return await readSummary(`${date.replaceAll('-', '')}_summary.txt`)
   } catch {

--- a/apps/reader/lib/public-archive.ts
+++ b/apps/reader/lib/public-archive.ts
@@ -1,0 +1,154 @@
+export const PUBLICATION_START_DATE = '2025-01-01'
+export const PUBLIC_ARCHIVE_PAGE_SIZE = 250
+
+export type PublicArchiveKind = 'diary' | 'novel'
+
+export type PublicArchiveEntry = {
+  id: string
+  date: string
+  title: string
+  content: string
+  imageUrl: string | null
+}
+
+type SupabaseConfig = {
+  url: string
+  key: string
+}
+
+type SupabaseRow = {
+  id: string
+  date: string
+  title: string
+  content: string
+  image_url: string | null
+  is_public: boolean
+}
+
+type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>
+
+const TABLE_BY_KIND: Record<PublicArchiveKind, 'daily_entries' | 'novels'> = {
+  diary: 'daily_entries',
+  novel: 'novels',
+}
+
+export const getSupabaseConfig = (): SupabaseConfig | null => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+
+  return url && key ? { url, key } : null
+}
+
+const parseExactCount = (contentRange: string | null) => {
+  const match = contentRange?.match(/\/(\d+)$/)
+  if (!match) {
+    throw new Error('Supabase response is missing an exact Content-Range count')
+  }
+  return Number(match[1])
+}
+
+const assertPublicRow = (row: SupabaseRow) => {
+  if (row.is_public !== true) {
+    throw new Error(`Private row reached the public Reader boundary: ${row.id}`)
+  }
+  if (row.date < PUBLICATION_START_DATE) {
+    throw new Error(`Pre-publication row reached the public Reader boundary: ${row.id}`)
+  }
+}
+
+export const fetchAllPublicArchiveEntries = async ({
+  config,
+  fetchImpl = fetch,
+  kind,
+  pageSize = PUBLIC_ARCHIVE_PAGE_SIZE,
+}: {
+  config: SupabaseConfig
+  fetchImpl?: FetchLike
+  kind: PublicArchiveKind
+  pageSize?: number
+}): Promise<PublicArchiveEntry[]> => {
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw new Error('pageSize must be a positive integer')
+  }
+
+  const table = TABLE_BY_KIND[kind]
+  const entries: PublicArchiveEntry[] = []
+  const seenIds = new Set<string>()
+  let expectedTotal: number | null = null
+  let offset = 0
+
+  while (expectedTotal === null || entries.length < expectedTotal) {
+    const url = new URL(`${config.url.replace(/\/$/, '')}/rest/v1/${table}`)
+    url.searchParams.set('select', 'id,date,title,content,image_url,is_public')
+    url.searchParams.set('is_public', 'eq.true')
+    url.searchParams.set('date', `gte.${PUBLICATION_START_DATE}`)
+    url.searchParams.set('order', 'date.desc,id.asc')
+    url.searchParams.set('limit', String(pageSize))
+    url.searchParams.set('offset', String(offset))
+
+    const response = await fetchImpl(url, {
+      headers: {
+        apikey: config.key,
+        Prefer: 'count=exact',
+      },
+      next: { revalidate: 300 },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Supabase ${table} request failed: ${response.status}`)
+    }
+
+    const total = parseExactCount(response.headers.get('content-range'))
+    if (expectedTotal === null) {
+      expectedTotal = total
+    } else if (total !== expectedTotal) {
+      throw new Error(
+        `Supabase ${table} count changed during pagination: ${expectedTotal} -> ${total}`,
+      )
+    }
+
+    const rows = (await response.json()) as SupabaseRow[]
+    if (rows.length > pageSize) {
+      throw new Error(`Supabase ${table} returned more rows than requested`)
+    }
+
+    for (const row of rows) {
+      assertPublicRow(row)
+      if (seenIds.has(row.id)) {
+        throw new Error(`Duplicate public Reader row across pages: ${row.id}`)
+      }
+      seenIds.add(row.id)
+      entries.push({
+        id: row.id,
+        date: row.date,
+        title: row.title,
+        content: row.content,
+        imageUrl: row.image_url ?? null,
+      })
+    }
+
+    if (rows.length === 0) break
+    offset += rows.length
+  }
+
+  if (expectedTotal === null || entries.length !== expectedTotal) {
+    throw new Error(
+      `Incomplete Supabase ${table} pagination: expected ${expectedTotal ?? 'unknown'}, got ${entries.length}`,
+    )
+  }
+
+  return entries
+}
+
+export const getRemotePublicArchiveEntries = async (
+  kind: PublicArchiveKind,
+): Promise<PublicArchiveEntry[] | null> => {
+  const config = getSupabaseConfig()
+  if (!config) return null
+  return fetchAllPublicArchiveEntries({ config, kind })
+}

--- a/apps/reader/tests/public-archive.test.ts
+++ b/apps/reader/tests/public-archive.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  PUBLICATION_START_DATE,
+  fetchAllPublicArchiveEntries,
+  type PublicArchiveKind,
+} from '../lib/public-archive'
+
+type Row = {
+  id: string
+  date: string
+  title: string
+  content: string
+  image_url: string | null
+  is_public: boolean
+}
+
+const config = { url: 'https://example.invalid', key: '' }
+
+const responseFor = (rows: Row[], offset: number, total: number) =>
+  new Response(JSON.stringify(rows), {
+    status: rows.length === total ? 200 : 206,
+    headers: {
+      'content-range':
+        rows.length === 0 ? `*/${total}` : `${offset}-${offset + rows.length - 1}/${total}`,
+    },
+  })
+
+const makeRows = (count: number, prefix = 'entry'): Row[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `${prefix}-${String(index).padStart(3, '0')}`,
+    date: `2026-08-${String(31 - index).padStart(2, '0')}`,
+    title: `${prefix} ${index}`,
+    content: `content ${index}`,
+    image_url: index % 2 === 0 ? null : `https://example.invalid/${prefix}-${index}.webp`,
+    is_public: true,
+  }))
+
+const makePagedFetch = (rows: Row[]) => async (input: string | URL | Request) => {
+  const url = input instanceof URL ? input : new URL(typeof input === 'string' ? input : input.url)
+  const offset = Number(url.searchParams.get('offset') ?? '0')
+  const limit = Number(url.searchParams.get('limit') ?? '250')
+  expect(url.searchParams.get('is_public')).toBe('eq.true')
+  expect(url.searchParams.get('date')).toBe(`gte.${PUBLICATION_START_DATE}`)
+  expect(url.searchParams.get('order')).toBe('date.desc,id.asc')
+  return responseFor(rows.slice(offset, offset + limit), offset, rows.length)
+}
+
+for (const kind of ['diary', 'novel'] as const satisfies readonly PublicArchiveKind[]) {
+  describe(`${kind} public archive`, () => {
+    test('retrieves every row exactly once across page sizes and accepts missing images', async () => {
+      for (let count = 0; count <= 17; count += 1) {
+        const rows = makeRows(count, kind)
+        for (let pageSize = 1; pageSize <= 5; pageSize += 1) {
+          const result = await fetchAllPublicArchiveEntries({
+            config,
+            fetchImpl: makePagedFetch(rows),
+            kind,
+            pageSize,
+          })
+          expect(result.map(entry => entry.id)).toEqual(rows.map(row => row.id))
+          expect(new Set(result.map(entry => entry.id)).size).toBe(count)
+          expect(result.length).toBe(count)
+        }
+      }
+    })
+  })
+}
+
+describe('public Reader fail-closed boundaries', () => {
+  test('rejects a private row returned by the upstream service', async () => {
+    const row = { ...makeRows(1)[0], is_public: false }
+    await expect(
+      fetchAllPublicArchiveEntries({
+        config,
+        fetchImpl: async () => responseFor([row], 0, 1),
+        kind: 'diary',
+        pageSize: 1,
+      }),
+    ).rejects.toThrow('Private row reached the public Reader boundary')
+  })
+
+  test('fixtures the publication boundary and rejects older rows', async () => {
+    const row = { ...makeRows(1)[0], date: '2024-12-31' }
+    expect(PUBLICATION_START_DATE).toBe('2025-01-01')
+    await expect(
+      fetchAllPublicArchiveEntries({
+        config,
+        fetchImpl: async () => responseFor([row], 0, 1),
+        kind: 'novel',
+        pageSize: 1,
+      }),
+    ).rejects.toThrow('Pre-publication row reached the public Reader boundary')
+  })
+
+  test('rejects duplicate rows across pages', async () => {
+    const rows = makeRows(3)
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = input instanceof URL ? input : new URL(typeof input === 'string' ? input : input.url)
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      return offset === 0
+        ? responseFor(rows.slice(0, 2), 0, 3)
+        : responseFor([rows[1], rows[2]], 2, 3)
+    }
+    await expect(
+      fetchAllPublicArchiveEntries({ config, fetchImpl, kind: 'diary', pageSize: 2 }),
+    ).rejects.toThrow('Duplicate public Reader row across pages')
+  })
+
+  test('rejects a missing page instead of returning a partial archive', async () => {
+    const rows = makeRows(4)
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = input instanceof URL ? input : new URL(typeof input === 'string' ? input : input.url)
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      return offset === 0 ? responseFor(rows.slice(0, 2), 0, 4) : responseFor([], offset, 4)
+    }
+    await expect(
+      fetchAllPublicArchiveEntries({ config, fetchImpl, kind: 'diary', pageSize: 2 }),
+    ).rejects.toThrow('Incomplete Supabase daily_entries pagination')
+  })
+})


### PR DESCRIPTION
Advance #41.

- add fail-closed paged Supabase Data API reader for `daily_entries` and `novels`
- request only `is_public=true` rows on/after 2025-01-01 with deterministic ordering
- use exact `Content-Range` counts so missing pages cannot silently truncate the archive
- reject private/pre-publication rows, duplicate IDs, count drift, and overfull pages
- accept missing `image_url` without failing the archive
- connect Diary retrieval to the paged public archive while keeping the local fallback for credential-free builds
- add generative pagination coverage across Diary/Novel sizes and page sizes plus explicit privacy/duplicate/missing-page fixtures

The Novel Reader/permalink route itself remains owned by the staged Reader navigation work, so this PR does not enable a new UI route. The corresponding #41 permalink-parity criterion should remain open until that route exists.