### PR TITLE
Remove broken People Said fragment from Timeline

### DIFF
--- a/apps/reader/lib/timeline.ts
+++ b/apps/reader/lib/timeline.ts
@@ -81,7 +81,7 @@ const fromPeopleSaid = (entry: PeopleSaidEntry): TimelineArtifact => ({
   title: publicSpeakerLabel(entry.speakerLabel),
   text: entry.text,
   imageUrl: null,
-  href: `/people-said#claim-${encodeURIComponent(entry.id)}`,
+  href: '/people-said',
   occurredAt: entry.occurredAt,
 })
 


### PR DESCRIPTION
Completes the remaining #40 permalink integrity gap. Timeline already provides stable Diary and Novel detail permalinks. People Said has no per-entry detail/anchor contract, so the previous generated `#claim-*` fragment could point to no element. This changes that route to the existing `/people-said` public projection instead of emitting a broken fragment. No canonical/data-model change.