### PR TITLE
Expose Vercel deployment identity for production checks

### DIFF
--- a/apps/reader/app/api/health/route.ts
+++ b/apps/reader/app/api/health/route.ts
@@ -1,0 +1,18 @@
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return Response.json(
+    {
+      status: 'ok',
+      gitCommitSha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+      gitCommitRef: process.env.VERCEL_GIT_COMMIT_REF ?? null,
+      deploymentId: process.env.VERCEL_DEPLOYMENT_ID ?? null,
+      environment: process.env.VERCEL_ENV ?? null,
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    },
+  )
+}

--- a/apps/reader/tests/health-route.test.ts
+++ b/apps/reader/tests/health-route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { GET } from '../app/api/health/route'
+
+const ENV_KEYS = [
+  'VERCEL_GIT_COMMIT_SHA',
+  'VERCEL_GIT_COMMIT_REF',
+  'VERCEL_DEPLOYMENT_ID',
+  'VERCEL_ENV',
+] as const
+
+const originalEnvironment = Object.fromEntries(
+  ENV_KEYS.map(key => [key, process.env[key]]),
+)
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const originalValue = originalEnvironment[key]
+    if (originalValue === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalValue
+    }
+  }
+})
+
+describe('GET /api/health', () => {
+  it('returns Vercel deployment identity without caching', async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = '0123456789abcdef'
+    process.env.VERCEL_GIT_COMMIT_REF = 'main'
+    process.env.VERCEL_DEPLOYMENT_ID = 'dpl_example'
+    process.env.VERCEL_ENV = 'production'
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(payload).toEqual({
+      status: 'ok',
+      gitCommitSha: '0123456789abcdef',
+      gitCommitRef: 'main',
+      deploymentId: 'dpl_example',
+      environment: 'production',
+    })
+  })
+
+  it('returns null deployment metadata outside Vercel', async () => {
+    for (const key of ENV_KEYS) delete process.env[key]
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      status: 'ok',
+      gitCommitSha: null,
+      gitCommitRef: null,
+      deploymentId: null,
+      environment: null,
+    })
+  })
+})


### PR DESCRIPTION
## Why

Issue #42 requires production verification to identify the deployed commit and confirm that Vercel is serving a ready build. The current Vercel project has a failed latest production deployment, while the current `main` source has moved on from that failed build.

## Change

- add `GET /api/health`
- return Vercel-provided Git commit SHA/ref, deployment ID, and environment
- send `Cache-Control: no-store`
- add Vitest coverage for Vercel and non-Vercel environments

No dependencies, data formats, workflows, or README content are changed.

Refs #42